### PR TITLE
remove handled values

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
@@ -15,7 +15,7 @@ class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
 
     override val elementFilter = """
         nodes, ways with (
-         shop ~ yes|other|unknown|shop|fixme|retail
+         shop ~ yes|fixme|retail
          and !man_made
          and !historic
          and !military


### PR DESCRIPTION
this values are handled by https://wiki.openstreetmap.org/wiki/Mechanical_Edits/Mateusz_Konieczny_-_bot_account/fixing_malformed_shop_tags

two remaining ones are expected to be also handled, but that requires additional bot permission

this will reduce conflicts in merges (I plan to add shop ~ hobby in SC once new iD preset is released)

one of steps toward #411