### PR TITLE
Update AddBuildingColour.kt

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_colour/AddBuildingColour.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_colour/AddBuildingColour.kt
@@ -10,7 +10,7 @@ class AddBuildingColour : OsmFilterQuestType<BuildingColour>() {
     override val elementFilter = """
         ways, relations with
           ((building and building !~ no|construction|roof|carport)
-          or (building:part and building:part !~ no|construction|roof|carport))
+          or (building:part and building:part !~ no|construction|roof|carport|window))
           and !building:colour
           and (!indoor or indoor = no)
           and wall !~ no


### PR DESCRIPTION
Windows are usually transparent, so I think it should be ok to exclude them from the colour quest