### PR TITLE
WIP: Show abandoned and disused nodes in 'things' and 'places' overlays.

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/osm/Places.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/osm/Places.kt
@@ -6,13 +6,16 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Element
 
 /** Return whether this element is a kind of place, regardless whether it is currently vacant or
  *  not */
-fun Element.isPlaceOrDisusedPlace(): Boolean =
-    isPlace() || isDisusedPlace()
+fun Element.isKindOfPlace(): Boolean =
+    isPlace() || isDisusedPlace() || isAbandonedPlace()
 
 /** Return whether this element is a kind of disused or vacant place */
 fun Element.isDisusedPlace(): Boolean =
     IS_VACANT_PLACE_EXPRESSION.matches(this) ||
     this.asIfItWasnt("disused")?.let { IS_PLACE_EXPRESSION.matches(it) } == true
+
+fun Element.isAbandonedPlace(): Boolean =
+    this.asIfItWasnt("abandoned")?.let { IS_PLACE_EXPRESSION.matches(it) } == true
 
 fun Element.isPlace(): Boolean =
     IS_PLACE_EXPRESSION.matches(this)

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
@@ -4,14 +4,17 @@ import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpressio
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 
 /** Return whether this element is a kind of thing, regardless whether it is disused or not */
-fun Element.isThingOrDisusedThing(): Boolean =
-    isThing() || isDisusedThing()
+fun Element.isKindOfThing(): Boolean =
+    isThing() || isDisusedThing() || isAbandonedThing()
 
 fun Element.isThing(): Boolean =
     IS_THING_EXPRESSION.matches(this)
 
 fun Element.isDisusedThing(): Boolean =
     this.asIfItWasnt("disused")?.let { IS_THING_EXPRESSION.matches(it) } == true
+
+fun Element.isAbandonedThing(): Boolean =
+    this.asIfItWasnt("abandoned")?.let { IS_THING_EXPRESSION.matches(it) } == true
 
 /** Small map features that are often mapped as points and usually cannot be entered.
  *

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/Style.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/Style.kt
@@ -39,4 +39,6 @@ data class PointStyle(
     val label: String? = null,
     /** color to use for the icon */
     val color: String? = null,
+    /** night mode color for the icon */
+    val nightColor: String? = null,
 ) : Style

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/places/PlacesOverlay.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/places/PlacesOverlay.kt
@@ -7,8 +7,10 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement
+import de.westnordost.streetcomplete.osm.asIfItWasnt
+import de.westnordost.streetcomplete.osm.isAbandonedPlace
 import de.westnordost.streetcomplete.osm.isDisusedPlace
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.overlays.Color
 import de.westnordost.streetcomplete.overlays.Overlay
 import de.westnordost.streetcomplete.overlays.PointStyle
@@ -36,17 +38,25 @@ class PlacesOverlay(private val getFeature: (Element) -> Feature?) : Overlay {
     override fun getStyledElements(mapData: MapDataWithGeometry) =
         mapData
             .asSequence()
-            .filter { it.isPlaceOrDisusedPlace() }
-            .map { element ->
-                // show disused places always with the icon for "disused shop" icon
-                val icon = getFeature(element)?.icon?.let { presetIconIndex[it] }
-                    ?: if (element.isDisusedPlace()) R.drawable.preset_fas_store_alt_slash else null
-                    ?: R.drawable.preset_maki_shop
+            .filter { it.isKindOfPlace() }
+            .mapNotNull { element ->
+                val feature = getFeature(element)
+                    ?: element.asIfItWasnt("disused")?.let { getFeature(it) }
+                    ?: element.asIfItWasnt("abandoned")?.let { getFeature(it) }
+                    ?: return@mapNotNull null
+
+                val icon = feature.icon?.let { presetIconIndex[it] } ?: R.drawable.preset_maki_shop
 
                 val label = getNameLabel(element.tags)
 
                 val style = if (element is Node) {
-                    PointStyle(icon, label)
+                    PointStyle(icon, label,
+                        if (element.isDisusedPlace()) "#606269"
+                        else if (element.isAbandonedPlace()) "#B06269"
+                        else null,
+                        if (element.isDisusedPlace()) "#aaaaaf"
+                        else if (element.isAbandonedPlace()) "#ffaaaa"
+                        else null)
                 } else {
                     PolygonStyle(Color.INVISIBLE, icon, label)
                 }
@@ -63,5 +73,5 @@ class PlacesOverlay(private val getFeature: (Element) -> Feature?) : Overlay {
 
     override fun createForm(element: Element?) =
         // this check is necessary because the form shall not be shown for entrances
-        if (element == null || element.isPlaceOrDisusedPlace()) PlacesOverlayForm() else null
+        if (element == null || element.isKindOfPlace()) PlacesOverlayForm() else null
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/places/PlacesOverlayForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/places/PlacesOverlayForm.kt
@@ -20,6 +20,7 @@ import de.westnordost.streetcomplete.databinding.FragmentOverlayPlacesBinding
 import de.westnordost.streetcomplete.osm.POPULAR_PLACE_FEATURE_IDS
 import de.westnordost.streetcomplete.osm.applyReplacePlaceTo
 import de.westnordost.streetcomplete.osm.applyTo
+import de.westnordost.streetcomplete.osm.asIfItWasnt
 import de.westnordost.streetcomplete.osm.isDisusedPlace
 import de.westnordost.streetcomplete.osm.isPlace
 import de.westnordost.streetcomplete.osm.localized_name.LocalizedName
@@ -80,6 +81,7 @@ class PlacesOverlayForm : AbstractOverlayForm() {
 
         return getFeatureDictionaryFeature(element)
             ?: if (element.isDisusedPlace()) vacantShopFeature else null
+                ?: getAbandonedFeatureDictionaryFeature(element)
             ?: BaseFeature(
                 id = "shop/unknown",
                 names = listOf(requireContext().getString(R.string.unknown_shop_title)),
@@ -99,6 +101,13 @@ class PlacesOverlayForm : AbstractOverlayForm() {
             country = countryOrSubdivisionCode,
             geometry = geometryType,
         ).firstOrNull { it.toElement().isPlace() }
+    }
+
+    private fun getAbandonedFeatureDictionaryFeature(element: Element): Feature? {
+        val abandonedElement = element.asIfItWasnt("abandoned") ?: return null
+        val abandonedFeature = getFeatureDictionaryFeature(abandonedElement) ?: return null
+        val abandonedLabel = resources.getString(R.string.abandoned).uppercase()
+        return abandonedFeature.toPrefixedFeature("abandoned", abandonedLabel)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/things/ThingsOverlay.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/things/ThingsOverlay.kt
@@ -7,7 +7,11 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement
 import de.westnordost.streetcomplete.osm.asIfItWasnt
-import de.westnordost.streetcomplete.osm.isThingOrDisusedThing
+import de.westnordost.streetcomplete.osm.isAbandonedPlace
+import de.westnordost.streetcomplete.osm.isAbandonedThing
+import de.westnordost.streetcomplete.osm.isDisusedPlace
+import de.westnordost.streetcomplete.osm.isDisusedThing
+import de.westnordost.streetcomplete.osm.isKindOfThing
 import de.westnordost.streetcomplete.overlays.Color
 import de.westnordost.streetcomplete.overlays.Overlay
 import de.westnordost.streetcomplete.overlays.PointStyle
@@ -26,18 +30,23 @@ class ThingsOverlay(private val getFeature: (Element) -> Feature?) : Overlay {
     override fun getStyledElements(mapData: MapDataWithGeometry) =
         mapData
             .asSequence()
-            .filter { it.isThingOrDisusedThing() }
+            .filter { it.isKindOfThing() }
             .mapNotNull { element ->
-                // show disused things with the same icon as normal things because they usually look
-                // similar (a disused telephone booth still looks like a telephone booth, etc.)
                 val feature = getFeature(element)
                     ?: element.asIfItWasnt("disused")?.let { getFeature(it) }
+                    ?: element.asIfItWasnt("abandoned")?.let { getFeature(it) }
                     ?: return@mapNotNull null
 
                 val icon = feature.icon?.let { presetIconIndex[it] } ?: R.drawable.preset_maki_marker_stroked
 
                 val style = if (element is Node) {
-                    PointStyle(icon)
+                    PointStyle(icon, null,
+                        if (element.isDisusedThing()) "#606269"
+                        else if (element.isAbandonedThing()) "#B06269"
+                        else null,
+                        if (element.isDisusedThing()) "#9999AF"
+                        else if (element.isAbandonedThing()) "#FF99AF"
+                        else null)
                 } else {
                     PolygonStyle(Color.INVISIBLE, icon)
                 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/things/ThingsOverlayForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/things/ThingsOverlayForm.kt
@@ -54,6 +54,7 @@ class ThingsOverlayForm : AbstractOverlayForm() {
 
         return getFeatureDictionaryFeature(element)
             ?: getDisusedFeatureDictionaryFeature(element)
+            ?: getAbandonedFeatureDictionaryFeature(element)
             ?: BaseFeature(
                 id = "thing/unknown",
                 names = listOf(requireContext().getString(R.string.unknown_object)),
@@ -68,6 +69,12 @@ class ThingsOverlayForm : AbstractOverlayForm() {
         val disusedFeature = getFeatureDictionaryFeature(disusedElement) ?: return null
         val disusedLabel = resources.getString(R.string.disused).uppercase()
         return disusedFeature.toPrefixedFeature("disused", disusedLabel)
+    }
+    private fun getAbandonedFeatureDictionaryFeature(element: Element): Feature? {
+        val abandonedElement = element.asIfItWasnt("abandoned") ?: return null
+        val abandonedFeature = getFeatureDictionaryFeature(abandonedElement) ?: return null
+        val abandonedLabel = resources.getString(R.string.abandoned).uppercase()
+        return abandonedFeature.toPrefixedFeature("abandoned", abandonedLabel)
     }
 
     private fun getFeatureDictionaryFeature(element: Element): Feature? {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
@@ -43,7 +43,7 @@ import de.westnordost.streetcomplete.data.quest.QuestKey
 import de.westnordost.streetcomplete.data.visiblequests.HideQuestController
 import de.westnordost.streetcomplete.data.visiblequests.QuestsHiddenController
 import de.westnordost.streetcomplete.osm.applyReplacePlaceTo
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.ALL_PATHS
 import de.westnordost.streetcomplete.osm.ALL_ROADS
 import de.westnordost.streetcomplete.quests.custom.CustomQuestList
@@ -71,7 +71,6 @@ import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
 import kotlinx.datetime.toJavaLocalDate
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.koin.android.ext.android.inject
 import org.koin.core.qualifier.named
@@ -336,7 +335,7 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
     }
 
     protected fun replacePlace(extra: Boolean = true) {
-        if (element.isPlaceOrDisusedPlace()) {
+        if (element.isKindOfPlace()) {
             ShopGoneDialog(
                 requireContext(),
                 element,

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cards/AddAcceptsCards.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
 class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>() {
@@ -34,7 +34,7 @@ class AddAcceptsCards : OsmFilterQuestType<CardAcceptance>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_accepts_cards
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddAcceptsCardsForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.quests.YesNoQuestForm
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
@@ -66,7 +66,7 @@ class AddAcceptsCash : OsmFilterQuestType<Boolean>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_accepts_cash_title2
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = YesNoQuestForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/air_conditioning/AddAirConditioning.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/air_conditioning/AddAirConditioning.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.quests.YesNoQuestForm
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
@@ -33,7 +33,7 @@ class AddAirConditioning : OsmFilterQuestType<Boolean>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_airConditioning_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = YesNoQuestForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBicyclePump.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBicyclePump.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 import de.westnordost.streetcomplete.quests.YesNoQuestForm
 import de.westnordost.streetcomplete.util.ktx.toYesNo
@@ -31,7 +31,7 @@ class AddBicyclePump : OsmFilterQuestType<Boolean>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_air_pump_bicycle_shop_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = YesNoQuestForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBikeRepairAvailability.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddBikeRepairAvailability.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 import de.westnordost.streetcomplete.quests.YesNoQuestForm
 import de.westnordost.streetcomplete.util.ktx.toYesNo
@@ -32,7 +32,7 @@ class AddBikeRepairAvailability : OsmFilterQuestType<Boolean>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bicycle_shop_repair_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = YesNoQuestForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddSecondHandBicycleAvailability.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bike_shop/AddSecondHandBicycleAvailability.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddSecondHandBicycleAvailability : OsmFilterQuestType<SecondHandBicycleAvailability>() {
@@ -35,7 +35,7 @@ class AddSecondHandBicycleAvailability : OsmFilterQuestType<SecondHandBicycleAva
     override fun getTitle(tags: Map<String, String>) = R.string.quest_bicycle_shop_second_hand_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddSecondHandBicycleAvailabilityForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddGlutenFree.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddGlutenFree.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddGlutenFree : OsmFilterQuestType<DietAvailabilityAnswer>() {
@@ -37,7 +37,7 @@ class AddGlutenFree : OsmFilterQuestType<DietAvailabilityAnswer>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_glutenfree_name_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddDietTypeForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddHalal.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddHalal : OsmFilterQuestType<DietAvailabilityAnswer>() {
@@ -35,7 +35,7 @@ class AddHalal : OsmFilterQuestType<DietAvailabilityAnswer>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_halal_name_title2
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddDietTypeForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddKosher.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddKosher : OsmFilterQuestType<DietAvailabilityAnswer>() {
@@ -36,7 +36,7 @@ class AddKosher : OsmFilterQuestType<DietAvailabilityAnswer>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_kosher_name_title2
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddDietTypeForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegan.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.VEG
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddVegan : OsmFilterQuestType<DietAvailabilityAnswer>() {
@@ -41,7 +41,7 @@ class AddVegan : OsmFilterQuestType<DietAvailabilityAnswer>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_vegan_title2
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddDietTypeForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/diet_type/AddVegetarian.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.VEG
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddVegetarian : OsmFilterQuestType<DietAvailabilityAnswer>() {
@@ -37,7 +37,7 @@ class AddVegetarian : OsmFilterQuestType<DietAvailabilityAnswer>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_dietType_vegetarian_title2
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddDietTypeForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/hairdresser/AddHairdresserCustomers.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/hairdresser/AddHairdresserCustomers.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 
 class AddHairdresserCustomers : OsmFilterQuestType<HairdresserCustomers>() {
 
@@ -29,7 +29,7 @@ class AddHairdresserCustomers : OsmFilterQuestType<HairdresserCustomers>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_hairdresser_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddHairdresserCustomersForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/level/AddLevelForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/level/AddLevelForm.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.databinding.QuestLevelBinding
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.level.Level
 import de.westnordost.streetcomplete.osm.level.levelsIntersect
 import de.westnordost.streetcomplete.osm.level.parseLevelsOrNull
@@ -58,11 +58,11 @@ class AddLevelForm : AbstractOsmQuestForm<String>() {
         val shopsWithLevels = if (prefs.getBoolean(PREF_MORE_LEVELS, false))
                 mapData.filter { e ->
                     e.tags["level"] != null
-                        && (e.isPlaceOrDisusedPlace() || getIcon(featureDictionary, e) != null)
+                        && (e.isKindOfPlace() || getIcon(featureDictionary, e) != null)
                 }
             else
                 mapData.filter {
-                    it.tags["level"] != null && it.isPlaceOrDisusedPlace()
+                    it.tags["level"] != null && it.isKindOfPlace()
                 }
 
         shopElementsAndGeometry = shopsWithLevels.mapNotNull { e ->

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -14,7 +14,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.opening_hours.parser.isSupportedOpeningHours
 import de.westnordost.streetcomplete.osm.updateCheckDateForKey
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
@@ -170,7 +170,7 @@ class AddOpeningHours(
     }
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddOpeningHoursForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours_signed/CheckOpeningHoursSigned.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.getLastCheckDateKeys
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.setCheckDateForKey
 import de.westnordost.streetcomplete.osm.toCheckDate
 import de.westnordost.streetcomplete.osm.updateCheckDateForKey
@@ -57,7 +57,7 @@ class CheckOpeningHoursSigned(
         filter.matches(element)
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = YesNoQuestForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -10,7 +10,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.localized_name.applyTo
 import de.westnordost.streetcomplete.quests.fullElementSelectionDialog
 import de.westnordost.streetcomplete.quests.questPrefix
@@ -54,7 +54,7 @@ class AddPlaceName(
         filter.matches(element) && getFeature(element) != null
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddPlaceNameForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/seating/AddSeating.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/seating/AddSeating.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.util.ktx.toYesNo
 
 class AddSeating : OsmFilterQuestType<Seating>() {
@@ -31,7 +31,7 @@ class AddSeating : OsmFilterQuestType<Seating>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_seating_name_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = AddSeatingForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/CheckShopExistence.kt
@@ -11,7 +11,7 @@ import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.
 import de.westnordost.streetcomplete.osm.LAST_CHECK_DATE_KEYS
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.isPlace
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateCheckDate
 
 class CheckShopExistence(
@@ -52,7 +52,7 @@ class CheckShopExistence(
         element.isPlace()
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = CheckShopExistenceForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/CheckShopType.kt
@@ -12,7 +12,7 @@ import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.applyReplacePlaceTo
 import de.westnordost.streetcomplete.osm.isDisusedPlace
 import de.westnordost.streetcomplete.osm.isPlace
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateCheckDate
 
 class CheckShopType : OsmElementQuestType<ShopTypeAnswer> {
@@ -58,7 +58,7 @@ class CheckShopType : OsmElementQuestType<ShopTypeAnswer> {
         !element.isPlace()
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = ShopTypeForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/shop_type/SpecifyShopType.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.applyReplacePlaceTo
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.removeCheckDates
 import de.westnordost.streetcomplete.osm.removePlaceRelatedTags
 
@@ -43,7 +43,7 @@ class SpecifyShopType : OsmFilterQuestType<ShopTypeAnswer>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_shop_type_title2
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = ShopTypeForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/smoking/AddSmoking.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/smoking/AddSmoking.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddSmoking : OsmFilterQuestType<SmokingAllowed>() {
@@ -48,7 +48,7 @@ class AddSmoking : OsmFilterQuestType<SmokingAllowed>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_smoking_title2
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = SmokingAllowedForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/swimming_pool_availability/AddSwimmingPoolAvailability.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/swimming_pool_availability/AddSwimmingPoolAvailability.kt
@@ -7,7 +7,6 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 
 class AddSwimmingPoolAvailability : OsmFilterQuestType<SwimmingPoolAvailability>() {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.WHEELCHAIR
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.osm.isPlaceOrDisusedPlace
+import de.westnordost.streetcomplete.osm.isKindOfPlace
 
 class AddWheelchairAccessBusiness : OsmFilterQuestType<WheelchairAccess>() {
 
@@ -122,7 +122,7 @@ class AddWheelchairAccessBusiness : OsmFilterQuestType<WheelchairAccess>() {
     override fun getTitle(tags: Map<String, String>) = R.string.quest_wheelchairAccess_outside_title
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
-        getMapData().asSequence().filter { it.isPlaceOrDisusedPlace() }
+        getMapData().asSequence().filter { it.isKindOfPlace() }
 
     override fun createForm() = WheelchairAccessForm()
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
@@ -252,9 +252,16 @@ class StyleableOverlayMapComponent(
             is PointStyle -> {
                 if (style.icon != null) {
                     p.addProperty("icon", context.resources.getResourceEntryName(style.icon))
-                    val color = style.color ?: if (isNightMode) "#ccf" else "#124"
+                    val color =
+                        if (isNightMode) style.nightColor ?: style.color ?: "#ccf"
+                        else style.color ?: "#124"
                     p.addProperty("icon-color", color)
-                    val haloColor = style.color?.let { getDarkenedColor(it) } ?: if (isNightMode) "#2e2e48" else "#fff"
+                    val haloColor =
+                        if (isNightMode)
+                            style.nightColor?.let { getDarkenedColor(it) }
+                            ?: style.color?.let { getDarkenedColor(it) }
+                            ?: "#2e2e48"
+                        else "#fff"
                     p.addProperty("icon-halo-color", haloColor)
                 }
                 if (style.label != null) p.addProperty("label", style.label)
@@ -384,7 +391,7 @@ class StyleableOverlayMapComponent(
         darkenedColors.getOrPut(color) {
             val rgb = color.toRgb()
             val hsv = rgb.toHsv()
-            val darkenedHsv = hsv.copy(value = hsv.value * 2 / 3)
+            val darkenedHsv = hsv.copy(value = hsv.value / 3)
             darkenedHsv.toRgb().toHexString()
         }
 

--- a/app/src/androidMain/res/values-ast/strings.xml
+++ b/app/src/androidMain/res/values-ast/strings.xml
@@ -781,7 +781,7 @@ Repara en qu'esta aplicación solo pide'l númberu de portal d'un edificiu en sa
     <string name="default_disabled_msg_go_inside_regional_warning">"Esti tipu de xera ta desactivada de serie porque nun ye útil en dalgunes rexones y seguramente tengas d'entrar nel sitiu p'alcontrar la información y responder bien a les preguntes."</string>
     <string name="quest_dietType_explanation_kosher">"Los productos kosher han preparase d'una manera especial, hai axencias que los certifiquen denomaes \"kashrut\"."</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure">"Nun hai carril bici nengún equí."</string>
-    <string name="quest_cycleway_answer_no_bicycle_infrastructure_explanation">"Pa completar la xera, como siempre; toca un llau de la vía, escueyi la respuesta y fai lo mesmo nel otru llau. 
+    <string name="quest_cycleway_answer_no_bicycle_infrastructure_explanation">"Pa completar la xera, como siempre; toca un llau de la vía, escueyi la respuesta y fai lo mesmo nel otru llau.
 
 Repara en toles opciones disponibles: a veces nun ye tan obvio, como en víes d'un solu sentíu con dos direcciones de carril bici."</string>
     <string name="quest_cycleway_answer_no_bicycle_infrastructure_title">"Marcando como que nun hai carril bici"</string>
@@ -1335,6 +1335,7 @@ Dalgunes capes tamién permiten añader datos que falten al traviés del marcado
     <string name="overlay_places">"Sitios"</string>
     <string name="overlay_things">"Coses"</string>
     <string name="disused">"en desusu"</string>
+    <string name="abandoned">abandoned</string>
     <string name="unknown_object">"Oxetu desconocíu"</string>
     <string name="quest_leafType_tree_title">"¿Esti árbol tien fueya ancho o en forma d'aguya?"</string>
     <string name="quest_bbq_fuel_gas">"Gas"</string>

--- a/app/src/androidMain/res/values-el/strings.xml
+++ b/app/src/androidMain/res/values-el/strings.xml
@@ -1332,6 +1332,7 @@
     <string name="overlay_places">"Μέρη"</string>
     <string name="overlay_things">"Πράγματα"</string>
     <string name="disused">"αχρησιμοποίητο"</string>
+    <string name="abandoned">εγκαταλειμμένο</string>
     <string name="unknown_object">"Άγνωστο αντικείμενο"</string>
     <string name="quest_leafType_tree_title">"Αυτό το δέντρο έχει βελόνες ή φύλλα;"</string>
     <string name="quest_bbq_fuel_gas">"Καύσιμο"</string>

--- a/app/src/androidMain/res/values-en-rAU/strings.xml
+++ b/app/src/androidMain/res/values-en-rAU/strings.xml
@@ -1346,6 +1346,7 @@ Additionally, some overlays allow you to add new data at the position of a displ
     <string name="overlay_places">"Places"</string>
     <string name="overlay_things">"Things"</string>
     <string name="disused">"disused"</string>
+    <string name="abandoned">abandoned</string>
     <string name="unknown_object">"Unknown object"</string>
     <string name="quest_leafType_tree_title">"Does this tree have needles or leaves?"</string>
     <string name="quest_bbq_fuel_gas">"Gas"</string>

--- a/app/src/androidMain/res/values-en/strings.xml
+++ b/app/src/androidMain/res/values-en/strings.xml
@@ -1785,6 +1785,7 @@ Partially means that a wheelchair can enter and use the restroom, but no handrai
 
     <string name="overlay_things">Things</string>
     <string name="disused">disused</string>
+    <string name="abandoned">abandoned</string>
     <string name="unknown_object">Unknown object</string>
 
     <string name="overlay_street_parking">Street parking</string>

--- a/app/src/androidMain/res/values/strings.xml
+++ b/app/src/androidMain/res/values/strings.xml
@@ -1785,6 +1785,7 @@ Partially means that a wheelchair can enter and use the restroom, but no handrai
 
     <string name="overlay_things">Things</string>
     <string name="disused">disused</string>
+    <string name="abandoned">abandoned</string>
     <string name="unknown_object">Unknown object</string>
 
     <string name="overlay_street_parking">Street parking</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,8 @@
+buildscript {
+    val agp_version by extra("8.9.3")
+    val agp_version1 by extra("8.7.2")
+    val agp_version2 by extra("8.9.3")
+}
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,4 @@
+#Sat Aug 09 11:18:26 EEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip


### PR DESCRIPTION
This patch intents to propose a solution for #831.

With this patch:
- abandoned nodes are now shown in 'things' and 'places' overlays;
- disused nodes are tinted gray;
- abandoned nodes are tinted red;
- abandoned nodes contain '(ABANDONED)' in their label, just like disused nodes contain '(DISUSED)' in the current version;
- disused shops now show the appropriate shop icon instead of a 'vacant' shop icon, as the state of disuse is marked by the icon color already.

Some improvements needed to be made to how icons are colored in night mode to accomodate tinted icons.

Since it's my first time working with the SC(EE) codebase and Kotlin/Android code in general, feedback is greatly appreciated :)