### PR TITLE
Update osmSpecies.txt

### DIFF
--- a/app/src/androidMain/assets/tree/osmSpecies.txt
+++ b/app/src/androidMain/assets/tree/osmSpecies.txt
@@ -43,6 +43,7 @@ Aesculus carnea
 Aesculus glabra
 Aesculus hippocastanum
 Aesculus rubicunda
+Aesculus × carnea
 Aesculus x carnea
 Agave tequilana F.A.C.Weber
 Agonis flexuosa
@@ -312,6 +313,7 @@ Populus tremula
 Populus tremula 'Erecta'
 Populus tremuloides
 Populus x canadensis
+Populus × canescens
 Populus x canescens
 Populus x euramericana
 Prosopis chilensis
@@ -428,6 +430,7 @@ Tilia mongolica
 Tilia platyphyllos
 Tilia platyphyllos Scop.
 Tilia tomentosa
+Tilia × euchlora
 Tilia x euchlora
 Tilia x europaea
 Tilia x flavescens Glenleven

--- a/app/src/androidMain/assets/tree/osmSpecies.txt
+++ b/app/src/androidMain/assets/tree/osmSpecies.txt
@@ -78,7 +78,6 @@ Betula pubescens
 Betula utilis
 Betula verrucosa
 Brachychiton populneus
-Branchychiton populneus
 Broussonetia papyrifera
 Buxus sempervirens
 Caesalpinia pluviosa DC.
@@ -134,7 +133,6 @@ Crataegus laevigata 'Paul's Scarlet'
 Crataegus monogyna
 Crataegus monogyna 'Stricta'
 Crataegus oxyacantha
-Crataegus x lavallei
 Crataegus X prunifolia
 Cryptomeria japonica
 Cupressocyparis leylandii
@@ -215,7 +213,6 @@ Larix decidua
 Larix laricina
 Laurus nobilis
 Ligustrum japonica
-Ligustrum japonica "variegata"
 Ligustrum japonicum
 Ligustrum lucidum
 Ligustrum vulgare
@@ -329,7 +326,6 @@ Prunus cerasifera 'Pissardii'
 Prunus cerasus
 Prunus domestica
 Prunus dulcis
-Prunus hillierii x Spire
 Prunus laurocerasus
 Prunus lusitanica
 Prunus maackii
@@ -459,4 +455,3 @@ Wodyetia bifurcata
 Zelkova carpinifolia
 Zelkova serrata
 Zelkova serrata Green Vase
-Zellkova serrata

--- a/app/src/androidMain/assets/tree/osmSpecies.txt
+++ b/app/src/androidMain/assets/tree/osmSpecies.txt
@@ -39,12 +39,10 @@ Acer saccharum
 Acer x freemanii
 Adansonia digitata
 Adansonia grandidieri
-Aesculus carnea
 Aesculus glabra
 Aesculus hippocastanum
 Aesculus rubicunda
 Aesculus × carnea
-Aesculus x carnea
 Agave tequilana F.A.C.Weber
 Agonis flexuosa
 Ailanthus altissima
@@ -417,7 +415,6 @@ Tilia cordata
 Tilia cordata Green Spire
 Tilia cordata Mill.
 Tilia cordata 'Rancho'
-Tilia euchlora
 Tilia europaea
 Tilia europaea Pallida
 Tilia mongolica
@@ -425,7 +422,6 @@ Tilia platyphyllos
 Tilia platyphyllos Scop.
 Tilia tomentosa
 Tilia × euchlora
-Tilia x euchlora
 Tilia x europaea
 Tilia x flavescens Glenleven
 Tilia x intermedia

--- a/app/src/androidMain/assets/tree/osmSpecies.txt
+++ b/app/src/androidMain/assets/tree/osmSpecies.txt
@@ -221,7 +221,6 @@ Liquidambar styraciflua Worplesdon
 Liriodendron tulipifera
 Lophostemon confertus
 Luma apiculata
-Magnolia Galaxy
 Magnolia grandiflora
 Magnolia kobus
 Malus domestica
@@ -314,7 +313,6 @@ Populus × canescens
 Populus x canescens
 Populus x euramericana
 Prosopis chilensis
-Prunus Accolade
 Prunus 'Amanogawa'
 Prunus armeniaca
 Prunus avium
@@ -442,7 +440,6 @@ Ulmus americana 'Brandon'
 Ulmus carpinifolia
 Ulmus glabra
 Ulmus hollandica
-Ulmus hybride Lobel
 Ulmus laevis
 Ulmus minor
 Ulmus parvifolia

--- a/app/src/androidMain/assets/tree/osmSpecies.txt
+++ b/app/src/androidMain/assets/tree/osmSpecies.txt
@@ -112,7 +112,6 @@ Chamaecyparis lawsoniana
 Chamaecyparis lawsoniana Columnaris
 Chamaerops excelsa
 Chamaerops humilis
-Ciconia ciconia
 Cinnamomum camphora
 Citrus × aurantium
 Citrus × sinensis

--- a/app/src/androidMain/assets/tree/osmSpecies.txt
+++ b/app/src/androidMain/assets/tree/osmSpecies.txt
@@ -22,20 +22,16 @@ Acer griseum
 Acer negundo
 Acer palmatum
 Acer platanoides
-Acer platanoïdes
-Acer platanoïdes Columnare
 Acer platanoides 'Crimson King'
 Acer platanoides 'Globosum'
 Acer platanoides 'Purpureum'
 Acer platanoides 'Schwedleri'
 Acer pseudoplatanus
 Acer pseudoplatanus 'Atropurpureum'
-Acer psuedoplatanus
 Acer rubrum
 Acer rubrum "Armstrong"
 Acer rubrum Morgan
 Acer rubrum Red Sunset
-Acer saccarinum
 Acer saccharinum
 Acer saccharinum laciniatum
 Acer saccharinum Laciniatum Wieri
@@ -61,13 +57,11 @@ Alnus viridis
 Amelanchier canadensis
 Amelanchier laevis
 Amelanchier lamarckii
-Ananas comosus Merr.
 Angophora costata
 Araucaria araucana
 Araucaria heterophylla
 Arbutus unedo
 Azadirachta indica
-Azardiraecta indica
 Banksia integrifolia
 Banksia marginata
 Bauhinia kalbreyeri Harms.
@@ -78,7 +72,6 @@ Betula nigra
 Betula papyrifera
 Betula pendula
 Betula pendula Dalecarlica
-Betula platyphylla Sukaczev var. japonica H.Hara
 Betula populifolia
 Betula pubescens
 Betula utilis
@@ -93,19 +86,16 @@ Callistemon salignus
 Callistemon viminalis
 Calocedrus decurrens
 Camellia sinensis
-Camellia sinensis Kuntze
 Carica papaya
 Carica papaya L.
 Carpinus betulus
 Carpinus betulus 'Fastigiata'
 Carpinus betulus 'Frans Fontaine'
-Carya illinoinensis K.Koch
 Castanea dentata
 Castanea sativa
 Casuarina cunninghamiana
 Casuarina glauca
 Catalpa bignonioides
-Catalpa bungeii
 Cedrus atlantica
 Cedrus atlantica glauca
 Cedrus deodara
@@ -127,7 +117,6 @@ Cinnamomum camphora
 Citrus × aurantium
 Citrus × sinensis
 Cocos nucifera
-Cocos nucifera L.
 Coprosma repens
 Cordyline australis
 Cornus florida
@@ -238,7 +227,6 @@ Luma apiculata
 Magnolia Galaxy
 Magnolia grandiflora
 Magnolia kobus
-Magnolia x soulangiana
 Malus domestica
 Malus 'Evereste'
 Malus floribunda
@@ -260,7 +248,6 @@ Melaleuca linariifolia
 Melaleuca nesophila
 Melaleuca styphelioides
 Melia azedarach
-Melia azederach
 Metasequoia glyptostroboides
 Metrosideros excelsa
 Morus alba
@@ -271,7 +258,6 @@ Nothofagus dombeyi
 Nothofagus obliqua
 Olea europaea
 Olea europea
-Opuntia ficus-indica Mill.
 Ostrya carpinifolia
 Parrotia persica
 Paulownia tomentosa
@@ -283,7 +269,6 @@ Phoenix dactylifera
 Phoenix dactylifera L.
 Photinia serrulata
 Picea abies
-Picea abies Karst.
 Picea glauca
 Picea mariana
 Picea omorika
@@ -323,7 +308,6 @@ Populus deltoides
 Populus nigra
 Populus nigra 'Italica'
 Populus pyramidalis
-Populus robusta
 Populus simonii
 Populus tremula
 Populus tremula 'Erecta'
@@ -344,9 +328,7 @@ Prunus cerasifera 'Pissardii'
 Prunus cerasus
 Prunus domestica
 Prunus dulcis
-Prunus dulcis D.A.Webb
 Prunus hillierii x Spire
-Prunus kanzan
 Prunus laurocerasus
 Prunus lusitanica
 Prunus maackii
@@ -365,7 +347,6 @@ Prunus 'Tai Haku'
 Prunus 'Umineko'
 Prunus virginiana
 Prunus Virginiana `Schubert`
-Prunus x hillieri Spire
 Prunus x schmittii
 Prunus × yedoensis
 Pseudotsuga menziesii
@@ -399,11 +380,9 @@ Quercus rubra
 Quercus suber
 Quillaja saponaria
 Rhus typhina
-River Red Gum
 Robinia pseudoacacia
 Robinia umbraculifera
 Roystonea regia
-SA Blue Gum
 Salix alba
 Salix alba 'Tristis'
 Salix babylonica
@@ -452,8 +431,6 @@ Tilia platyphyllos Scop.
 Tilia tomentosa
 Tilia x euchlora
 Tilia x europaea
-Tilia x europea
-Tilia x europeana
 Tilia x flavescens Glenleven
 Tilia x intermedia
 Tilia x vulgaris

--- a/app/src/androidMain/assets/tree/osmSpecies.txt
+++ b/app/src/androidMain/assets/tree/osmSpecies.txt
@@ -180,7 +180,6 @@ Fraxinus ornus
 Fraxinus oxycarpa
 Fraxinus oxycarpa 'Raywood'
 Fraxinus pennsylvanica
-Fraxinus raywoodii
 Fraxinus velutina
 Gevuina avellana
 Ginkgo biloba

--- a/app/src/androidMain/assets/tree/osmSpecies.txt
+++ b/app/src/androidMain/assets/tree/osmSpecies.txt
@@ -290,7 +290,6 @@ Platanus acerifolia
 Platanus hybrida
 Platanus occidentalis
 Platanus orientalis
-Platanus Platanor "Vallis Clausa"
 Platanus x acerifolia
 Platanus x hybrida
 Populus alba
@@ -338,7 +337,7 @@ Prunus 'Sunset Boulevard'
 Prunus 'Tai Haku'
 Prunus 'Umineko'
 Prunus virginiana
-Prunus Virginiana `Schubert`
+Prunus virginiana 'Schubert'
 Prunus x schmittii
 Prunus × yedoensis
 Pseudotsuga menziesii

--- a/app/src/androidMain/assets/tree/osmSpecies.txt
+++ b/app/src/androidMain/assets/tree/osmSpecies.txt
@@ -327,7 +327,6 @@ Prunus lusitanica
 Prunus maackii
 Prunus padus
 Prunus persica
-Prunus Persica
 Prunus sargentii
 Prunus sargentii "Yedoensis"
 Prunus serotina
@@ -356,7 +355,6 @@ Quercus coccinea
 Quercus frainetto
 Quercus fusiformis
 Quercus ilex
-Quercus Ilex
 Quercus imbricaria
 Quercus macrocarpa
 Quercus muehlenbergii


### PR DESCRIPTION
This is a new attempt to clean up osmSpecies.txt, that is hopefully less controversial than #676.

- removed values that no longer exist in taginfo (typos and invalid names that were fixed in OSM)
- removed `Ciconia ciconia` (White Stork)
- added correctly spelled hybrid names (`… × …`), if they are more popular in taginfo than the spelling with `x`

Additionally i propose to remove incorrect spellings, if the correct spelling is more popular, e.g. remove `Aesculus carnea` and `Aesculus x carnea` in favor of `Aesculus × carnea`.

There is an ongoing unrelated effort to fix such errors in OSM that has more information and discussion about the various problems: https://community.openstreetmap.org/t/massive-edit-fixing-typos-and-other-errors-in-species-for-trees/143760/1