### PR TITLE
Fix ClassCastException in MainActivity and InsertNodeFragment by using project's CountryBoundaries interface instead of library's

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
@@ -42,7 +42,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
-import de.westnordost.countryboundaries.CountryBoundaries
+import de.westnordost.streetcomplete.util.countryboundaries.CountryBoundaries
 import de.westnordost.osmfeatures.Feature
 import androidx.lifecycle.lifecycleScope
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
@@ -334,7 +334,7 @@ class MainActivity :
             }
             if (addPoiAt.value != null) {
                 val pos = addPoiAt.value ?: return@content
-                val country = countryBoundaries.value.getIds(pos.longitude, pos.latitude).firstOrNull()
+                val country = countryBoundaries.value.getIds(pos).firstOrNull()
                 val defaultFeatureIds: List<String> = prefs.getString(Prefs.CREATE_POI_RECENT_FEATURE_IDS, "")
                     .split("§").filter { it.isNotBlank() && it != "shop" }
                     .ifEmpty { POPULAR_PLACE_FEATURE_IDS }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/InsertNodeFragment.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/InsertNodeFragment.kt
@@ -33,7 +33,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import com.russhwolf.settings.ObservableSettings
-import de.westnordost.countryboundaries.CountryBoundaries
+import de.westnordost.streetcomplete.util.countryboundaries.CountryBoundaries
 import de.westnordost.osmfeatures.Feature
 import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.osmfeatures.GeometryType
@@ -186,7 +186,7 @@ class InsertNodeFragment :
             if (showDialog.value) {
                 val pow = positionOnWay ?: return@setContent
                 val fd = featureDictionary.value
-                val country = countryBoundaries.value.getIds(pow.position.longitude, pow.position.latitude).firstOrNull()
+                val country = countryBoundaries.value.getIds(pow.position).firstOrNull()
                 val defaultFeatureIds = prefs.getString(Prefs.INSERT_NODE_RECENT_FEATURE_IDS, "")
                     .split("§").filter { it.isNotBlank() }
                     .ifEmpty { listOf("amenity/post_box", "barrier/gate", "highway/crossing/unmarked", "highway/crossing/uncontrolled", "highway/traffic_signals", "barrier/bollard", "traffic_calming/table") }


### PR DESCRIPTION
Fixed crash when opening POI menu