### PR TITLE
Fixes #943: Enter EVSE IDs by scanning QR code

### DIFF
--- a/app/src/commonMain/composeResources/values/strings_ee.xml
+++ b/app/src/commonMain/composeResources/values/strings_ee.xml
@@ -690,6 +690,8 @@
     <string name="quest_evse_id_title">What is the EVSE ID of this charging station?</string>
     <string name="quest_evse_id_add_more">Add another EVSE ID</string>
     <string name="quest_evse_id_hint">e.g. DE*GCE*E1234567</string>
+    <string name="quest_evse_id_scan_more">Scan another EVSE ID</string>
+    <string name="quest_evse_id_scan_unknown_value">QR code not recognized. Please open an issue and attach an image of the QR code so we can add support.</string>
 
     <!-- new overlays -->
 
@@ -773,6 +775,7 @@ Out of the box SCEE is configured to behave very similar to StreetComplete.</str
     <!-- actually there are still SC translations available, as only the main string has been removed from SC. -->
     <string name="close">Close</string>
     <string name="fixme_for_object">Another person added a fixme:</string>
+    <string name="no_qr_code_handler">No QR code scanner found. Install a compatible app like Binary Eye and try again.</string>
     <string name="quest_roofOrientation_along">Parallel to the building’s longer side</string>
     <string name="quest_roofOrientation_across">Parallel to the building’s shorter side</string>
     <string name="quest_roofOrientation_title">How is the roof ridge oriented?</string>

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/evse_id/AddEvseId.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/evse_id/AddEvseId.kt
@@ -1,9 +1,12 @@
 package de.westnordost.streetcomplete.quests.evse_id
 
-import androidx.compose.foundation.text.KeyboardActions
+import android.widget.Toast
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.core.net.toUri
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.CountryInfo
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
@@ -14,16 +17,36 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.Answer
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
-import de.westnordost.streetcomplete.util.countryboundaries.NoCountriesExcept
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CITIZEN
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.resources.Res
 import de.westnordost.streetcomplete.resources.*
+import de.westnordost.streetcomplete.resources.Res
 import de.westnordost.streetcomplete.ui.common.quest.AnswerItem
-import de.westnordost.streetcomplete.ui.common.quest.MultiValueQuestForm
+import de.westnordost.streetcomplete.ui.common.quest.MultiValueQuestQrScanForm
+import de.westnordost.streetcomplete.util.countryboundaries.NoCountriesExcept
 import de.westnordost.streetcomplete.util.math.contains
+import io.ktor.client.HttpClient
+import io.ktor.client.request.request
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import java.util.Locale
+
+val urlPrefixToQueryParameter = mapOf(
+    "http://m.intercharge.eu/qr" to "evseid",
+    "https://charge.elli.eco/" to "evseid",
+    "https://e-mobility.lidl.de/qr" to "evseid",
+    "https://smatrics.com/start-charging" to "evseId",
+    "https://www.aral-pulse.de/webshop/details" to "evseid",
+)
+val urlPrefixesWithEvseIdAsPath = arrayOf(
+    "https://laden.enercity.de/",
+    "https://pay.chargedrive.com/",
+    "https://qr.on-charge.com/",
+    "www.chargepoint-services.com/",
+)
 
 class AddEvseId : OsmElementQuestType<String> {
 
@@ -81,11 +104,29 @@ class AddEvseId : OsmElementQuestType<String> {
 
     @Composable
     override fun Form(on: (QuestAction<String>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {
-        MultiValueQuestForm(
+        val composableScope = rememberCoroutineScope()
+        val context = LocalContext.current
+
+        val scanUnknownValueToastText = stringResource(Res.string.quest_evse_id_scan_unknown_value)
+
+        MultiValueQuestQrScanForm(
             on,
-            Res.string.quest_evse_id_add_more,
+            addAnotherValueText = Res.string.quest_evse_id_add_more,
+            scanAnotherValueText = Res.string.quest_evse_id_scan_more,
             otherAnswers = { listOf(AnswerItem(stringResource(Res.string.quest_generic_answer_noSign)) { on(Answer("ref:signed=no")) }) },
             isOk = { EVSE_REGEX.matches(it) },
+            onQrCodeParsed = {
+                value: String, addValue: (String?) -> Unit ->
+                    composableScope.launch {
+                        val result = parseQrCodeValue(value)
+
+                        if (result != null) {
+                            addValue(result)
+                        } else {
+                            Toast.makeText(context, scanUnknownValueToastText, Toast.LENGTH_LONG).show()
+                        }
+                    }
+            },
             keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
             hint = stringResource(Res.string.quest_evse_id_hint)
         )
@@ -115,3 +156,53 @@ class AddEvseId : OsmElementQuestType<String> {
 }
 
 private val EVSE_REGEX = Regex("(?i)^[A-Z]{2}\\*?[A-Z0-9]{3}\\*?E(?!\\*)[A-Z0-9*]{1,31}$")
+private val EVSE_REGEX_IN_TEXT = Regex("(?i)[A-Z]{2}\\*?[A-Z0-9]{3}\\*?E(?!\\*)[A-Z0-9*]{1,31}")
+
+private suspend fun followRedirect(url: String): String? {
+    val client = HttpClient { followRedirects = false }
+    val response: HttpResponse = client.request(url) {
+        method = HttpMethod.Head
+    }
+    return response.headers[HttpHeaders.Location]
+}
+
+// Some of the QR codes contain a URL that is missing the protocol.
+private fun normalizeUrl(url: String): String = if (url.startsWith("http")) url else "https://$url"
+
+private fun getUrlQueryParameter(url: String, queryParameter: String): String? {
+    val uri = normalizeUrl(url).toUri()
+    return uri.getQueryParameter(queryParameter)
+}
+
+private fun getUrlPath(url: String): String? {
+    val uri = normalizeUrl(url).toUri()
+    return uri.path?.replace("/", "")
+}
+
+private suspend fun parseQrCodeValue(value: String): String? {
+    urlPrefixToQueryParameter.forEach { (urlPrefix, queryParameter) ->
+        if (value.startsWith(urlPrefix))
+            return getUrlQueryParameter(value, queryParameter)
+    }
+
+    urlPrefixesWithEvseIdAsPath.forEach { urlPrefix ->
+        if (value.startsWith(urlPrefix))
+            return getUrlPath(value)
+    }
+
+    if (value.startsWith("https://chrg.me")) {
+        val redirectedLocation = followRedirect(value) ?: return null
+        return getUrlQueryParameter(redirectedLocation, "evseId")
+    }
+
+    arrayOf("evseid", "evseId").forEach { queryParameter ->
+        val maybeEvseId = getUrlQueryParameter(value, queryParameter)
+        if (maybeEvseId != null && EVSE_REGEX.matches(maybeEvseId)) return maybeEvseId
+    }
+
+    val regexMatch = EVSE_REGEX_IN_TEXT.find(value)
+    if (regexMatch != null)
+        return regexMatch.value
+
+    return null
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/evse_id/AddEvseId.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/evse_id/AddEvseId.kt
@@ -1,10 +1,12 @@
 package de.westnordost.streetcomplete.quests.evse_id
 
-import android.widget.Toast
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.core.net.toUri
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
@@ -21,6 +23,7 @@ import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.resources.*
 import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.ui.common.ToastPopup
 import de.westnordost.streetcomplete.ui.common.quest.AnswerItem
 import de.westnordost.streetcomplete.ui.common.quest.MultiValueQuestQrScanForm
 import de.westnordost.streetcomplete.util.countryboundaries.NoCountriesExcept
@@ -33,20 +36,6 @@ import io.ktor.http.HttpMethod
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import java.util.Locale
-
-val urlPrefixToQueryParameter = mapOf(
-    "http://m.intercharge.eu/qr" to "evseid",
-    "https://charge.elli.eco/" to "evseid",
-    "https://e-mobility.lidl.de/qr" to "evseid",
-    "https://smatrics.com/start-charging" to "evseId",
-    "https://www.aral-pulse.de/webshop/details" to "evseid",
-)
-val urlPrefixesWithEvseIdAsPath = arrayOf(
-    "https://laden.enercity.de/",
-    "https://pay.chargedrive.com/",
-    "https://qr.on-charge.com/",
-    "www.chargepoint-services.com/",
-)
 
 class AddEvseId : OsmElementQuestType<String> {
 
@@ -104,32 +93,33 @@ class AddEvseId : OsmElementQuestType<String> {
 
     @Composable
     override fun Form(on: (QuestAction<String>) -> Unit, element: Element, geometry: ElementGeometry, countryInfo: CountryInfo) {
+        var showScanUnknownValueToast by remember { mutableStateOf(false) }
         val composableScope = rememberCoroutineScope()
-        val context = LocalContext.current
-
-        val scanUnknownValueToastText = stringResource(Res.string.quest_evse_id_scan_unknown_value)
 
         MultiValueQuestQrScanForm(
-            on,
+            on = on,
             addAnotherValueText = Res.string.quest_evse_id_add_more,
             scanAnotherValueText = Res.string.quest_evse_id_scan_more,
             otherAnswers = { listOf(AnswerItem(stringResource(Res.string.quest_generic_answer_noSign)) { on(Answer("ref:signed=no")) }) },
             isOk = { EVSE_REGEX.matches(it) },
-            onQrCodeParsed = {
-                value: String, addValue: (String?) -> Unit ->
-                    composableScope.launch {
-                        val result = parseQrCodeValue(value)
+            onQrCodeParsed = { value: String, addValue: (String?) -> Unit ->
+                composableScope.launch {
+                    val result = parseQrCodeValue(value)
 
-                        if (result != null) {
-                            addValue(result)
-                        } else {
-                            Toast.makeText(context, scanUnknownValueToastText, Toast.LENGTH_LONG).show()
-                        }
-                    }
+                    if (result != null) addValue(result)
+                    else showScanUnknownValueToast = true
+                }
             },
             keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
             hint = stringResource(Res.string.quest_evse_id_hint)
         )
+
+        if (showScanUnknownValueToast) {
+            ToastPopup(
+                onDismissRequest = { showScanUnknownValueToast = false },
+                text = stringResource(Res.string.quest_evse_id_scan_unknown_value),
+            )
+        }
     }
 
     override fun applyAnswerTo(
@@ -156,7 +146,21 @@ class AddEvseId : OsmElementQuestType<String> {
 }
 
 private val EVSE_REGEX = Regex("(?i)^[A-Z]{2}\\*?[A-Z0-9]{3}\\*?E(?!\\*)[A-Z0-9*]{1,31}$")
-private val EVSE_REGEX_IN_TEXT = Regex("(?i)[A-Z]{2}\\*?[A-Z0-9]{3}\\*?E(?!\\*)[A-Z0-9*]{1,31}")
+private val EVSE_REGEX_IN_TEXT = Regex("(?i)\\b[A-Z]{2}\\*[A-Z0-9]{3}\\*E(?!\\*)[A-Z0-9*]{1,31}\\b")
+
+private val urlPrefixToQueryParameter = mapOf(
+    "http://m.intercharge.eu/qr" to "evseid",
+    "https://charge.elli.eco/" to "evseid",
+    "https://e-mobility.lidl.de/qr" to "evseid",
+    "https://smatrics.com/start-charging" to "evseId",
+    "https://www.aral-pulse.de/webshop/details" to "evseid",
+)
+private val urlPrefixesWithEvseIdAsPath = arrayOf(
+    "https://laden.enercity.de/",
+    "https://pay.chargedrive.com/",
+    "https://qr.on-charge.com/",
+    "www.chargepoint-services.com/",
+)
 
 private suspend fun followRedirect(url: String): String? {
     val client = HttpClient { followRedirects = false }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/MultiValueQrScanQuestForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/MultiValueQrScanQuestForm.kt
@@ -1,0 +1,88 @@
+package de.westnordost.streetcomplete.ui.common.quest
+
+import android.app.Activity.RESULT_OK
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
+import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.resources.no_qr_code_handler
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import kotlin.collections.plus
+
+@Composable
+fun MultiValueQuestQrScanForm(
+    on: (QuestAction<String>) -> Unit,
+    addAnotherValueText: StringResource,
+    scanAnotherValueText: StringResource,
+    noQrCodeHandlerResId: StringResource = Res.string.no_qr_code_handler,
+    modifier: Modifier = Modifier,
+    isOk: (String) -> Boolean = { true },
+    simpleSuggestions: Collection<String>? = null,
+    prioritySuggestions: (String) -> Collection<String>? = { null },
+    onQrCodeParsed: ((String, (String?) -> Unit) -> Unit)? = null,
+    minLengthForSuggestions: Int = 1,
+    otherAnswers: @Composable (() -> List<AnswerItem>) = { emptyList() },
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    hint: String? = null
+) {
+    var values by rememberSaveable { mutableStateOf(setOf<String>()) }
+
+    val context = LocalContext.current
+    val noQrCodeHandlerToastText = stringResource(noQrCodeHandlerResId)
+    val qrLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        result ->
+            if (result.resultCode == RESULT_OK) {
+                val content = result.data?.getStringExtra("SCAN_RESULT")
+                if (!content.isNullOrBlank()) {
+                    if (onQrCodeParsed != null) {
+                        onQrCodeParsed(content) {
+                            if (it != null) values = values + it
+                        }
+                    } else {
+                         values = values + content
+                    }
+                }
+            }
+    }
+
+    MultiValueQuestForm(
+        on,
+        values,
+        onValuesChange = { values = it },
+        addAnotherValueText,
+        modifier,
+        isOk,
+        simpleSuggestions,
+        prioritySuggestions,
+        minLengthForSuggestions,
+        otherAnswers,
+        keyboardOptions,
+        hint
+    ) {
+        TextButton(
+            onClick = {
+                try {
+                    qrLauncher.launch(Intent("com.google.zxing.client.android.SCAN"))
+                } catch (_: ActivityNotFoundException) {
+                    Toast.makeText(context, noQrCodeHandlerToastText, Toast.LENGTH_LONG).show()
+                }
+            }
+        ) {
+            Text(stringResource(scanAnotherValueText))
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/MultiValueQrScanQuestForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/MultiValueQrScanQuestForm.kt
@@ -3,7 +3,6 @@ package de.westnordost.streetcomplete.ui.common.quest
 import android.app.Activity.RESULT_OK
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.text.KeyboardOptions
@@ -12,13 +11,14 @@ import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
 import de.westnordost.streetcomplete.resources.Res
 import de.westnordost.streetcomplete.resources.no_qr_code_handler
+import de.westnordost.streetcomplete.ui.common.ToastPopup
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import kotlin.collections.plus
@@ -40,9 +40,8 @@ fun MultiValueQuestQrScanForm(
     hint: String? = null
 ) {
     var values by rememberSaveable { mutableStateOf(setOf<String>()) }
+    var showNoQrCodeHandlerToast by remember { mutableStateOf(false) }
 
-    val context = LocalContext.current
-    val noQrCodeHandlerToastText = stringResource(noQrCodeHandlerResId)
     val qrLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         result ->
             if (result.resultCode == RESULT_OK) {
@@ -60,29 +59,36 @@ fun MultiValueQuestQrScanForm(
     }
 
     MultiValueQuestForm(
-        on,
-        values,
+        on = on,
+        values = values,
         onValuesChange = { values = it },
-        addAnotherValueText,
-        modifier,
-        isOk,
-        simpleSuggestions,
-        prioritySuggestions,
-        minLengthForSuggestions,
-        otherAnswers,
-        keyboardOptions,
-        hint
+        addAnotherValueText = addAnotherValueText,
+        modifier = modifier,
+        isOk = isOk,
+        simpleSuggestions = simpleSuggestions,
+        prioritySuggestions = prioritySuggestions,
+        minLengthForSuggestions = minLengthForSuggestions,
+        otherAnswers = otherAnswers,
+        keyboardOptions = keyboardOptions,
+        hint = hint
     ) {
         TextButton(
             onClick = {
                 try {
                     qrLauncher.launch(Intent("com.google.zxing.client.android.SCAN"))
                 } catch (_: ActivityNotFoundException) {
-                    Toast.makeText(context, noQrCodeHandlerToastText, Toast.LENGTH_LONG).show()
+                    showNoQrCodeHandlerToast = true
                 }
             }
         ) {
             Text(stringResource(scanAnotherValueText))
+        }
+
+        if (showNoQrCodeHandlerToast) {
+            ToastPopup(
+                onDismissRequest = { showNoQrCodeHandlerToast = false },
+                text = stringResource(noQrCodeHandlerResId),
+            )
         }
     }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/MultiValueQuestForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/MultiValueQuestForm.kt
@@ -45,19 +45,19 @@ fun MultiValueQuestForm(
     var values by rememberSaveable { mutableStateOf(setOf<String>()) }
 
     MultiValueQuestForm(
-        on,
-        values,
+        on = on,
+        values = values,
         onValuesChange = { values = it },
-        addAnotherValueText,
-        modifier,
-        isOk,
-        simpleSuggestions,
-        prioritySuggestions,
-        minLengthForSuggestions,
-        otherAnswers,
-        keyboardOptions,
-        hint,
-        additionalButtons
+        addAnotherValueText = addAnotherValueText,
+        modifier = modifier,
+        isOk = isOk,
+        simpleSuggestions = simpleSuggestions,
+        prioritySuggestions = prioritySuggestions,
+        minLengthForSuggestions = minLengthForSuggestions,
+        otherAnswers = otherAnswers,
+        keyboardOptions = keyboardOptions,
+        hint = hint,
+        additionalButtons = additionalButtons
     )
 }
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/MultiValueQuestForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/MultiValueQuestForm.kt
@@ -39,9 +39,44 @@ fun MultiValueQuestForm(
     minLengthForSuggestions: Int = 1,
     otherAnswers: @Composable (() -> List<AnswerItem>) = { emptyList() },
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    hint: String? = null
+    hint: String? = null,
+    additionalButtons: @Composable (() -> Unit)? = null
 ) {
     var values by rememberSaveable { mutableStateOf(setOf<String>()) }
+
+    MultiValueQuestForm(
+        on,
+        values,
+        onValuesChange = { values = it },
+        addAnotherValueText,
+        modifier,
+        isOk,
+        simpleSuggestions,
+        prioritySuggestions,
+        minLengthForSuggestions,
+        otherAnswers,
+        keyboardOptions,
+        hint,
+        additionalButtons
+    )
+}
+
+@Composable
+fun MultiValueQuestForm(
+    on: (QuestAction<String>) -> Unit,
+    values: Set<String>,
+    onValuesChange: (Set<String>) -> Unit,
+    addAnotherValueText: StringResource,
+    modifier: Modifier = Modifier,
+    isOk: (String) -> Boolean = { true },
+    simpleSuggestions: Collection<String>? = null,
+    prioritySuggestions: (String) -> Collection<String>? = { null },
+    minLengthForSuggestions: Int = 1,
+    otherAnswers: @Composable (() -> List<AnswerItem>) = { emptyList() },
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    hint: String? = null,
+    additionalButtons: @Composable (() -> Unit)? = null
+) {
     var currentValue by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue()) }
     val isTooLong by remember { derivedStateOf { values.sumOf { it.length + 1 } + currentValue.text.length > MAX_OSM_TAG_VALUE_LENGTH } }
     val prefs: Preferences = koinInject()
@@ -76,11 +111,17 @@ fun MultiValueQuestForm(
                 startExpanded = true,
                 startExpandedWithoutFocus = true
             )
-            TextButton(
-                onClick = { values = values + currentValue.text.trim(); currentValue = TextFieldValue() }, // todo: show dropdown if minLengthForSuggestions is 0, also on start
-                enabled = currentValue.text.isNotBlank() && isOk(currentValue.text) && currentValue.text.trim() !in values
-            ) {
-                Text(stringResource(addAnotherValueText))
+            Column {
+                TextButton(
+                    onClick = {
+                        onValuesChange(values + currentValue.text.trim()); currentValue = TextFieldValue()
+                    }, // todo: show dropdown if minLengthForSuggestions is 0, also on start
+                    enabled = currentValue.text.isNotBlank() && isOk(currentValue.text) && currentValue.text.trim() !in values
+                ) {
+                    Text(stringResource(addAnotherValueText))
+                }
+
+                additionalButtons?.invoke()
             }
         }
     }


### PR DESCRIPTION
This PR builds on #889 and adds the feature for scanning the EVSE ID from a QR code as suggested in the original discussion in #444 and requested again in #943.

https://github.com/user-attachments/assets/864128f5-4cb4-4d96-a1b4-b8c2675df85d

As suggested in https://github.com/Helium314/SCEE/issues/444#issuecomment-1669117065, the feature works by calling an external QR code scanner. It uses the `com.google.zxing.client.android.SCAN` intent, originally from the zxing app (https://github.com/zxing/zxing/wiki/Scanning-Via-Intent). But the intent is also commonly implemented by other QR scanners. I came across this in Binary Eye, which explicitly advertises the feature (https://github.com/markusfisch/BinaryEye#scan-intent). I also tested QR & Barcode Scanner (https://github.com/wewewe718/QrAndBarcodeScanner/blob/da922e7b96906ec55a7437733378e850ca9262f7/app/src/main/java/com/example/barcodescanner/feature/tabs/scan/ScanBarcodeFromCameraFragment.kt#L227).

I've added support for all QR code formats that I have seen in the wild as well as those I found online (see below). If anyone has more examples, I'm happy to implement them as well. Otherwise, it's easy to add support later.

A few more notes:

- I did consider adding a regex extract as a fallback but was worried about matching too much since the length varies (https://wiki.openstreetmap.org/wiki/Key:ref:EU:EVSE#Syntax).
- Given that all the URL formats in `urlPrefixToQueryParameter` use `evseid` or `evseId` as the parameter anyway, technically that code isn't really necessary and we could also just rely on the generic URL parameter fallback. Personally, I like the more explicit approach but I'm happy to change that.
- chrg.me codes (example: `https://chrg.me/KeM8sr`) annoyingly don't include the EVSE directly but redirect to a URL that does. I implemented handling for this, but I'm not sure whether we're okay with just making random network requests.
- I'll apologize in advance for any non-idiomatic code patterns. I have no experience with Android and especially Kotlin.

<details>
<summary>QR codes I used for testing</summary>

- https://elli.my.site.com/csmfaqs/s/article/what-is-an-evse-id-and-where-do-i-find-it?language=en_US
- https://support.ladeverbundplus.de/support/solutions/articles/101000392352-die-evse-id
- https://www.goingelectric.de/forum/viewtopic.php?t=69273
- https://chargepoint-supplies.com/aufkleber/5/vaylens-ladepunkt-sticker-mit-eigener-id-anfrage
- https://community.openstreetmap.org/t/e-auto-ladesaule-welche-angaben-zum-taggen-finde-ich-vor-ort/101617

<img width="616" height="787" alt="image" src="https://github.com/user-attachments/assets/e9ccf060-13da-480a-bcd2-3ee7b7678498" />

<img width="1495" height="720" alt="image" src="https://github.com/user-attachments/assets/d669d7ba-49d8-4a50-9cfe-550b024c6c00" />

<img width="966" height="671" alt="image" src="https://github.com/user-attachments/assets/0c1591e6-776d-488f-84b6-6a1cec1ae7d3" />

<img width="844" height="551" alt="image" src="https://github.com/user-attachments/assets/fbf382ac-0f55-4782-8c27-406a35e39c7c" />

(Fake) example of a QR code that isn't explicitly handled but will fall back to the regex parsing:

<img width="206" height="203" alt="image" src="https://github.com/user-attachments/assets/0ff57d94-1256-4087-9949-653dbf9af77f" />

</details>