### PR TITLE
Fix several Compose quest UI regressions

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/guidepost/AddGuidepostName.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/guidepost/AddGuidepostName.kt
@@ -54,12 +54,14 @@ class AddGuidepostName : OsmFilterQuestType<GuidepostNameAnswer>() {
                 listOf(AnswerItem(stringResource(Res.string.quest_placeName_no_name_answer)) { confirmNoName = true })
             }
         )
-        AreYouSureDialog(
-            onDismissRequest = { confirmNoName = false },
-            onConfirmed = { on(Answer(NoVisibleGuidepostName)) },
-            titleText = stringResource(Res.string.quest_name_answer_noName_confirmation_title),
-            confirmButtonText = stringResource(Res.string.quest_name_noName_confirmation_positive),
-        )
+        if (confirmNoName) {
+            AreYouSureDialog(
+                onDismissRequest = { confirmNoName = false },
+                onConfirmed = { on(Answer(NoVisibleGuidepostName)) },
+                titleText = stringResource(Res.string.quest_name_answer_noName_confirmation_title),
+                confirmButtonText = stringResource(Res.string.quest_name_noName_confirmation_positive),
+            )
+        }
     }
 
     override fun applyAnswerTo(answer: GuidepostNameAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/AddSmoothnessForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/AddSmoothnessForm.kt
@@ -34,12 +34,13 @@ fun AddSmoothnessForm(
     element: Element,
 ) {
     val surfaceTag = element.tags["surface"]
-    val items = remember(element) { Smoothness.entries.filter { it.getImage(surfaceTag) != null } }
+    val items = remember(surfaceTag) { smoothnessAnswersForSurface(surfaceTag) }
     val prefs: Preferences = koinInject()
 
     var showObstacleHint by remember { mutableStateOf(false) }
     var confirmSurface by remember { mutableStateOf<Surface?>(null) }
     val titleExtra = if (prefs.expertMode && surfaceTag != null) " ($surfaceTag)" else ""
+    val knownSurface = parseSurface(surfaceTag)?.takeIf { it != Surface.UNSUPPORTED }
 
     ItemSelectQuestForm(
         on = {
@@ -50,11 +51,12 @@ fun AddSmoothnessForm(
         },
         items = items,
         itemContent = { item ->
+            val illustrationSurface = item.getIllustrationSurface(surfaceTag)
             Box {
                 ImageWithDescription(
-                    painter = item.getImage(surfaceTag)?.let { painterResource(it) },
+                    painter = item.getImage(illustrationSurface)?.let { painterResource(it) },
                     title = stringResource(item.title),
-                    description = item.getDescription(surfaceTag)?.let { stringResource(it) }
+                    description = item.getDescription(illustrationSurface)?.let { stringResource(it) }
                 )
                 Image(
                     painter = painterResource(item.icon),
@@ -69,8 +71,12 @@ fun AddSmoothnessForm(
             else Res.string.quest_smoothness_road_title
         ) + titleExtra,
         otherAnswers = { listOfNotNull(
-            AnswerItem(stringResource(Res.string.quest_smoothness_wrong_surface)) {
-                confirmSurface = surfaceTag?.let { parseSurface(it) }
+            if (knownSurface != null) {
+                AnswerItem(stringResource(Res.string.quest_smoothness_wrong_surface)) {
+                    confirmSurface = knownSurface
+                }
+            } else {
+                null
             },
             if (element.couldBeSteps()) {
                 AnswerItem(stringResource(Res.string.quest_generic_answer_is_actually_steps)) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/SmoothnessItem.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/SmoothnessItem.kt
@@ -39,6 +39,22 @@ val Smoothness.title: StringResource get() = when (this) {
     IMPASSABLE ->    Res.string.quest_smoothness_title_impassable
 }
 
+/**
+ * Surface tag used to pick smoothness photos and descriptions.
+ *
+ * SCEE asks smoothness for more surfaces than StreetComplete. Surfaces without dedicated photos
+ * reuse generic asphalt (excellent/good) and gravel (worse) illustrations.
+ */
+fun Smoothness.getIllustrationSurface(surface: String?): String =
+    if (surface in SURFACES_FOR_SMOOTHNESS) surface!!
+    else when (this) {
+        EXCELLENT, GOOD -> "asphalt"
+        else -> "gravel"
+    }
+
+fun smoothnessAnswersForSurface(surface: String?): List<Smoothness> =
+    Smoothness.entries.filter { it.getImage(it.getIllustrationSurface(surface)) != null }
+
 fun Smoothness.getDescription(surface: String?): StringResource? = when (surface) {
     "asphalt", "concrete", "concrete:plates" -> pavedDescription
     "sett" -> settDescription

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/bottom_sheet/BottomSheetFormScaffold.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/bottom_sheet/BottomSheetFormScaffold.kt
@@ -44,7 +44,7 @@ fun BottomSheetFormScaffold(
     initialState: BottomSheetState =
         if (LocalWindowInfo.current.isLandscape) BottomSheetState.Expanded
         else BottomSheetState.Collapsed,
-    peekHeight: Dp = Dimensions.QuestFormPeekHeight
+    peekHeight: Dp = Dimensions.getQuestFormPeekHeight(LocalWindowInfo.current)
 ) {
     val windowInfo = LocalWindowInfo.current
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/item_select/ImageWithDescription.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/item_select/ImageWithDescription.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -13,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.Hyphens
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -36,8 +38,10 @@ fun ImageWithDescription(
             Image(
                 painter = painter,
                 contentDescription = null,
+                contentScale = ContentScale.Fit,
                 modifier = Modifier
                     .conditional(imageSize != null) { size(imageSize!!) }
+                    .conditional(imageSize == null) { sizeIn(maxWidth = 160.dp, maxHeight = 112.dp) }
                     .clip(MaterialTheme.shapes.medium)
             )
         }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/QuestAnswerButtonBar.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/QuestAnswerButtonBar.kt
@@ -1,9 +1,7 @@
 package de.westnordost.streetcomplete.ui.common.quest
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.DropdownMenu
@@ -17,6 +15,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.resources.*
@@ -27,29 +27,45 @@ import org.jetbrains.compose.resources.stringResource
 @Immutable
 data class AnswerItem(val text: String, val action: () -> Unit)
 
-/** Horizontal button bar for bottom sheets that can be multi-line if it does not all fit in one
- *  line and places subtle dividers in-between the [answers]. Also, optionally [otherAnswers] will
- *  be shown in a dropdown button aligned to the start of the bar. */
+/**
+ * Segmented answer button bar matching the pre-Compose FlexboxLayout behavior:
+ * every visible segment (including the optional "Uh…" other-answers control) shares the
+ * available width equally, with vertical dividers between segments and centered labels.
+ */
 @Composable
 fun QuestAnswerButtonBar(
     modifier: Modifier = Modifier,
     answers: List<AnswerItem> = emptyList(),
     otherAnswers: @Composable (() -> List<AnswerItem>)? = null,
 ) {
-    FlowRow(
+    if (otherAnswers == null && answers.isEmpty()) return
+
+    Row(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(4.dp, alignment = Alignment.End),
-        itemVerticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         if (otherAnswers != null) {
-            OtherAnswersTextButton(answers = otherAnswers)
-            Spacer(Modifier.weight(1f))
+            OtherAnswersTextButton(
+                answers = otherAnswers,
+                modifier = Modifier.weight(1f),
+            )
         }
         for ((index, item) in answers.withIndex()) {
             if (otherAnswers != null || index != 0) {
                 VerticalDivider(Modifier.height(24.dp))
             }
-            TextButton(onClick = item.action) { Text(item.text) }
+            TextButton(
+                onClick = item.action,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = item.text,
+                    textAlign = TextAlign.Center,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
     }
 }
@@ -62,8 +78,17 @@ private fun OtherAnswersTextButton(
     var expanded by rememberSaveable { mutableStateOf(false) }
 
     Box(modifier) {
-        TextButton(onClick = { expanded = true }) {
-            Text(stringResource(Res.string.quest_generic_otherAnswers2))
+        TextButton(
+            onClick = { expanded = true },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = stringResource(Res.string.quest_generic_otherAnswers2),
+                textAlign = TextAlign.Center,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
         DropdownMenu(
             expanded = expanded,
@@ -84,6 +109,20 @@ private fun QuestAnswerButtonBarPreview() {
     QuestAnswerButtonBar(
         answers = listOf(
             AnswerItem("No") {},
+            AnswerItem("Yes") {},
+        ),
+        otherAnswers = { listOf(
+            AnswerItem("Can't say") {}
+        ) }
+    )
+}
+
+@Preview
+@Composable
+private fun QuestAnswerButtonBarManyAnswersPreview() {
+    QuestAnswerButtonBar(
+        answers = listOf(
+            AnswerItem("No") {},
             AnswerItem("Perhaps") {},
             AnswerItem("Depends how you define \"No\"") {},
             AnswerItem("Yes") {},
@@ -91,7 +130,6 @@ private fun QuestAnswerButtonBarPreview() {
         otherAnswers = { listOf(
             AnswerItem("Depends how you define \"Yes\"") {},
             AnswerItem("Can't say") {}
-        )
-        }
+        ) }
     )
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/QuestAnswerContent.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/QuestAnswerContent.kt
@@ -32,7 +32,7 @@ fun QuestAnswerContent(
                         .fillMaxWidth()
                         .padding(contentPadding)
                         .clipToBounds(),
-                    contentAlignment = Alignment.Center,
+                    contentAlignment = Alignment.TopCenter,
                     content = content
                 )
             }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/theme/Dimensions.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/theme/Dimensions.kt
@@ -10,7 +10,10 @@ object Dimensions {
 
     val speechBubbleCornerRadius: Dp get() = 16.dp
 
-    val QuestFormPeekHeight = 400.dp
+    /** Collapsed quest form height as a fraction of the window, so list answers start well above
+     *  the bottom of the screen on both compact and tall devices. */
+    fun getQuestFormPeekHeight(windowInfo: WindowInfo): Dp =
+        windowInfo.containerDpSize.height * 0.62f
 
     fun getMaxQuestFormWidth(windowInfo: WindowInfo): Dp =
         if (windowInfo.isLandscape) {

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/guidepost/AddGuidepostNameTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/guidepost/AddGuidepostNameTest.kt
@@ -1,0 +1,25 @@
+package de.westnordost.streetcomplete.quests.guidepost
+
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
+import de.westnordost.streetcomplete.quests.answerApplied
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AddGuidepostNameTest {
+
+    private val questType = AddGuidepostName()
+
+    @Test fun `apply no name answer`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("name:signed", "no")),
+            questType.answerApplied(NoVisibleGuidepostName)
+        )
+    }
+
+    @Test fun `apply name answer`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("name", "Summit")),
+            questType.answerApplied(GuidepostName("Summit"))
+        )
+    }
+}

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/smoothness/SmoothnessItemKtTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/smoothness/SmoothnessItemKtTest.kt
@@ -1,0 +1,51 @@
+package de.westnordost.streetcomplete.quests.smoothness
+
+import de.westnordost.streetcomplete.quests.smoothness.Smoothness.BAD
+import de.westnordost.streetcomplete.quests.smoothness.Smoothness.EXCELLENT
+import de.westnordost.streetcomplete.quests.smoothness.Smoothness.GOOD
+import de.westnordost.streetcomplete.quests.smoothness.Smoothness.HORRIBLE
+import de.westnordost.streetcomplete.quests.smoothness.Smoothness.IMPASSABLE
+import de.westnordost.streetcomplete.quests.smoothness.Smoothness.INTERMEDIATE
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SmoothnessItemKtTest {
+
+    @Test fun `asphalt keeps dedicated photos and omits values without asphalt images`() {
+        assertEquals("asphalt", EXCELLENT.getIllustrationSurface("asphalt"))
+        assertNotNull(EXCELLENT.getImage("asphalt"))
+        assertNull(HORRIBLE.getImage("asphalt"))
+        assertEquals(
+            listOf(EXCELLENT, GOOD, INTERMEDIATE, BAD, Smoothness.VERY_BAD),
+            smoothnessAnswersForSurface("asphalt")
+        )
+    }
+
+    @Test fun `sett keeps dedicated photos`() {
+        assertEquals("sett", GOOD.getIllustrationSurface("sett"))
+        assertNull(EXCELLENT.getImage("sett"))
+        assertTrue(GOOD in smoothnessAnswersForSurface("sett"))
+    }
+
+    @Test fun `generic SCEE surfaces reuse asphalt and gravel illustrations`() {
+        val genericSurfaces = listOf(
+            "grass", "dirt", "sand", "mud", "ground", "unpaved", "woodchips",
+            "pebblestone", "grass_paver", "unhewn_cobblestone", "metal", "rock",
+            "laterite", "earth"
+        )
+        for (surface in genericSurfaces) {
+            assertEquals("asphalt", EXCELLENT.getIllustrationSurface(surface), surface)
+            assertEquals("asphalt", GOOD.getIllustrationSurface(surface), surface)
+            assertEquals("gravel", INTERMEDIATE.getIllustrationSurface(surface), surface)
+            assertEquals("gravel", IMPASSABLE.getIllustrationSurface(surface), surface)
+            val answers = smoothnessAnswersForSurface(surface)
+            assertEquals(Smoothness.entries, answers, surface)
+            for (answer in answers) {
+                assertNotNull(answer.getImage(answer.getIllustrationSurface(surface)), "$surface $answer")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes several regressions introduced during the Compose migration.

### Smoothness quest
- Restore smoothness answers for SCEE-specific surfaces such as `grass`, `dirt`, `sand`, etc.
- Reuse the generic asphalt / gravel illustrations as before the Compose migration.
- Keep the existing SCEE-specific smoothness quest coverage unchanged.

### Smoothness layout
- Increase the collapsed quest form height relative to the available window height.
- Limit smoothness illustration size and align the answer content at the top.
- This makes the answer list start significantly higher on tall devices.

### Quest answer button bar
- Restore the segmented single-row layout used before Compose.
- All visible answer buttons now share the available width equally.
- Vertical dividers are shown between segments.
- This fixes layouts such as `Uh… | No | Yes` being pushed awkwardly to one side.

## Testing

- `:app:compileAndroidMain`
- `:app:testAndroidHostTest`
- Smoothness-specific tests added for generic SCEE surfaces
- Manually tested on a Google Pixel 8 Pro