### PR TITLE
fix housenumber suggestion hidden until field interaction

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/address/AnAddressNumberInput.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/address/AnAddressNumberInput.kt
@@ -25,6 +25,14 @@ import de.westnordost.streetcomplete.ui.common.SwitchKeyboardPopupButton
 import de.westnordost.streetcomplete.ui.common.TextField2
 import de.westnordost.streetcomplete.ui.util.isImeVisible
 
+/**
+ * Material TextField only shows the placeholder while unfocused when [label] is null.
+ * Blank labels must therefore be treated as absent, otherwise the housenumber suggestion
+ * stays invisible until the field is focused (see Helium314/SCEE#918).
+ */
+fun effectiveAddressNumberLabel(label: String?): String? =
+    label?.takeIf { it.isNotEmpty() }
+
 /** An input field for adding some address number. There's something all these fields have in
  *  common, which is that
  *  - they are single-line text fields with auto-size on
@@ -52,6 +60,7 @@ fun AnAddressNumberInput(
 
     var isFocused by remember { mutableStateOf(false) }
     val showSwitchKeyboardPopup = isFocused && isImeVisible()
+    val effectiveLabel = effectiveAddressNumberLabel(label)
 
     ProvideTextStyle(LocalTextStyle.current.copy(
         // to avoid the size of the text changing when going from e.g. "123j" to "123k"
@@ -68,7 +77,7 @@ fun AnAddressNumberInput(
                     valueState = it
                     onValueChange(valueState.text)
                 },
-                label = label?.let { { Text(it) } },
+                label = effectiveLabel?.let { { Text(it) } },
                 placeholder = if (!suggestion.isNullOrEmpty()) {
                     { BasicText(
                         text = suggestion,

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/address/HouseNumberForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/address/HouseNumberForm.kt
@@ -1,8 +1,6 @@
 package de.westnordost.streetcomplete.osm.address
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideTextStyle
@@ -30,7 +28,6 @@ fun HouseNumberForm(
                 onValueChange = { onValueChange(HouseNumber(it, value.unit)) },
                 modifier = modifier.weight(1f).widthIn(max = 256.dp),
                 suggestion = suggestion?.houseNumber,
-                label = ""
             )
             if (prefs.expertMode)
                 HouseNumberInput(

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/osm/address/AnAddressNumberInputKtTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/osm/address/AnAddressNumberInputKtTest.kt
@@ -1,0 +1,22 @@
+package de.westnordost.streetcomplete.osm.address
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AnAddressNumberInputKtTest {
+
+    @Test fun `null label stays null so suggestion can show while unfocused`() {
+        assertNull(effectiveAddressNumberLabel(null))
+    }
+
+    @Test fun `blank label is treated as absent so suggestion can show while unfocused`() {
+        // Empty string was previously passed for the housenumber field to align with the unit
+        // field in expert mode; Material then hid the placeholder until focus (SCEE#918).
+        assertNull(effectiveAddressNumberLabel(""))
+    }
+
+    @Test fun `non-empty label is kept`() {
+        assertEquals("unit", effectiveAddressNumberLabel("unit"))
+    }
+}


### PR DESCRIPTION
Empty label strings made Material hide the placeholder while unfocused. Restore StreetComplete behavior and guard blank labels (fixes #918).

<img width="487" height="282" alt="grafik" src="https://github.com/user-attachments/assets/98ee103e-bcb0-4888-84c2-c85256abcfc4" />
