### PR TITLE
Fix invisible access-manager delete icon in dark mode

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/AccessManagerDialog.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/AccessManagerDialog.kt
@@ -131,8 +131,9 @@ fun AccessManagerDialog(
                                         }
                                     ) {
                                         Icon(
-                                            painterResource(Res.drawable.ic_delete_24),
-                                            stringResource(Res.string.delete_confirmation)
+                                            painter = painterResource(Res.drawable.ic_delete_24),
+                                            contentDescription = stringResource(Res.string.delete_confirmation),
+                                            tint = MaterialTheme.colors.onSurface
                                         )
                                     }
                                 }


### PR DESCRIPTION
## Summary
- The trashcan icon to remove an access restriction was almost invisible in Dark mode (black on almost-black).
- Cause: `ic_delete_24` uses a hardcoded black fill, and the access manager dialog did not apply a theme-aware icon tint.
- Fix: tint the delete `Icon` with `MaterialTheme.colors.onSurface`.

## Test plan
- [x] `:app:compileAndroidMain` (BUILD SUCCESSFUL)
- [x] Manually: enable Dark mode, open the surface overlay, tap a way with `access=private`, choose Manage access..., confirm the trashcan is clearly visible

<img width="553" height="367" alt="grafik" src="https://github.com/user-attachments/assets/0a3629e4-9f50-4139-90cb-e640de496288" />


Fixes #909