### PR TITLE
Replace overflowing hide button text with an eye icon

### DIFF
--- a/app/src/commonMain/composeResources/drawable/ic_hide_24.xml
+++ b/app/src/commonMain/composeResources/drawable/ic_hide_24.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000"
+        android:fillType="evenOdd"
+        android:pathData="M12,5C7.5,5 3.7,8.1 2,12c1.7,3.9 5.5,7 10,7s8.3,-3.1 10,-7C20.3,8.1 16.5,5 12,5zM15.75,12a3.75,3.75 0 1 1,-7.5 0a3.75,3.75 0 1 1,7.5 0z"/>
+    <path
+        android:fillColor="#000"
+        android:pathData="M19,3.6L20.4,5 5,20.4 3.6,19z"/>
+</vector>
+<!-- from https://www.svgrepo.com/svg/453947/hide -->

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/QuestForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/QuestForm.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Icon
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -46,6 +47,7 @@ import de.westnordost.streetcomplete.util.ktx.isDeletable
 import de.westnordost.streetcomplete.util.ktx.isSplittable
 import de.westnordost.streetcomplete.util.nameAndLocationLabel
 import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
@@ -310,7 +312,10 @@ fun HideButton(onHide: () -> Unit, onTempHide: () -> Unit) {
             onClick = onTempHide,
             onLongClick = onHide
         ) {
-            Text(stringResource(Res.string.hide_button))
+            Icon(
+                painterResource(Res.drawable.ic_hide_24),
+                stringResource(Res.string.hide_button)
+            )
         }
 }
 


### PR DESCRIPTION
The button now uses a hide/eye-off icon instead of text. The existing hide_button string is kept as the icon content description.

<img width="123" height="179" alt="grafik" src="https://github.com/user-attachments/assets/d607d46e-b1f6-4a55-87eb-a548dd3a77cb" />


Fixes #950