### PR TITLE
Migrate restriction overlay to Compose

### DIFF
--- a/androidApp/src/main/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
+++ b/androidApp/src/main/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
@@ -297,6 +297,9 @@ class MainActivity :
                 onSetMapMarkers = { markers ->
                     mapFragment?.setMarkersForCurrentHighlighting(markers)
                 },
+                onSetOverlayVisible = { visible ->
+                    mapFragment?.setOverlayVisible(visible)
+                },
                 onSolvedQuest = { icon, position ->
                     val offset = root.getLocationInWindow()
                     val startPos = mapFragment?.getPointOf(position)!!

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -451,6 +451,9 @@ tasks.register<CopyIconsTask>("copyIconsToAndroid") {
         it.startsWith("quest_") ||
         it.startsWith("ic_quest_") ||
         it == "ic_custom_overlay.xml" ||
+        // RestrictionOverlay map pins + overlay icon (StyleableOverlayMapComponent needs Android IDs)
+        it.startsWith("ic_restriction_") ||
+        it == "ic_overlay_restriction.xml" ||
         it == "ic_add_poi.xml" ||
         it == "ic_edit_tags.xml" ||
         it.startsWith("crossing_markings") ||

--- a/app/src/androidHostTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayAndroidIconTest.kt
+++ b/app/src/androidHostTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayAndroidIconTest.kt
@@ -1,0 +1,26 @@
+package de.westnordost.streetcomplete.overlays.restriction
+
+import de.westnordost.streetcomplete.view.toAndroidResourceId
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression for StyleableOverlayMapComponent / GeometryMarkersMapComponent NPE:
+ * every RestrictionOverlay map icon must resolve via copyIconsToAndroid / IconIndex.
+ *
+ * Prefer [restrictionOverlayAndroidMapIcons] so newly added overlay map icons fail loudly.
+ */
+class RestrictionOverlayAndroidIconTest {
+
+    @Test fun `all RestrictionOverlay Android map icons resolve to resource ids`() {
+        val icons = restrictionOverlayAndroidMapIcons()
+        assertTrue(icons.isNotEmpty())
+        for (icon in icons) {
+            assertNotNull(
+                icon.toAndroidResourceId(),
+                "Missing Android IconIndex mapping for $icon — add it to copyIconsToAndroid"
+            )
+        }
+    }
+}

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -503,7 +503,11 @@ class MainMapFragment : MapFragment() {
     }
 
     fun hideOverlay() {
-        styleableOverlayMapComponent?.setVisible(false)
+        setOverlayVisible(false)
+    }
+
+    fun setOverlayVisible(visible: Boolean) {
+        styleableOverlayMapComponent?.setVisible(visible)
     }
 
     fun highlightGeometry(geometry: ElementGeometry) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/OverlaysRegistry.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/OverlaysRegistry.kt
@@ -17,6 +17,7 @@ import de.westnordost.streetcomplete.overlays.sidewalk.SidewalkOverlay
 import de.westnordost.streetcomplete.overlays.street_parking.StreetParkingOverlay
 import de.westnordost.streetcomplete.overlays.surface.SurfaceOverlay
 import de.westnordost.streetcomplete.overlays.things.ThingsOverlay
+import de.westnordost.streetcomplete.overlays.restriction.RestrictionOverlay
 import de.westnordost.streetcomplete.overlays.way_lit.WayLitOverlay
 
 fun overlaysRegistry(
@@ -38,6 +39,6 @@ fun overlaysRegistry(
     8 to ThingsOverlay(getFeature),
     7 to BuildingsOverlay(),
     9 to MtbScaleOverlay(),
-//    (EE_QUEST_OFFSET + 1) to RestrictionOverlay(),
+    (EE_QUEST_OFFSET + 1) to RestrictionOverlay(),
     (EE_QUEST_OFFSET + 0) to CustomOverlay(prefs),
 ))

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlay.kt
@@ -49,11 +49,13 @@ class RestrictionOverlay : Overlay {
 
     @Composable
     override fun Form(on: (OverlayAction) -> Unit, element: Element?, geometry: ElementGeometry, countryInfo: CountryInfo) {
-        TODO("Not yet implemented")
+        when {
+            element == null || element is Node ->
+                RestrictionOverlayNodeForm(on, element, geometry, countryInfo)
+            element is Way ->
+                RestrictionOverlayWayForm(on, element, geometry, countryInfo)
+        }
     }
-//    override fun createForm(element: Element?): AbstractOverlayForm = RestrictionOverlayNodeForm()
-//        if (element is Way) RestrictionOverlayWayForm()
-//        else RestrictionOverlayNodeForm() // node or null when inserting
 
     override val changesetComment: String = "Specify traffic restrictions"
     override val icon = Res.drawable.ic_overlay_restriction
@@ -111,9 +113,11 @@ private fun Relation.getColor(wayId: Long): Color {
 
 private fun getColor(role: String, restriction: String): Color = when {
     restriction.startsWith("no_") && role == "from" -> OverlayColor.Orange
-    restriction.startsWith("no_") && role == "to" -> darkerOrange
+    restriction.startsWith("no_") && role == "to" ->
+        Color(ColorUtils.blendARGB(OverlayColor.Orange.toArgb(), OverlayColor.Black.toArgb(), 0.75f))
     restriction.startsWith("only_") && role == "from" -> OverlayColor.Gold
-    restriction.startsWith("only_") && role == "to" -> darkerGold
+    restriction.startsWith("only_") && role == "to" ->
+        Color(ColorUtils.blendARGB(OverlayColor.Gold.toArgb(), OverlayColor.Black.toArgb(), 0.75f))
     role == "via" -> OverlayColor.Lime
     else -> OverlayColor.Black
 }
@@ -147,6 +151,3 @@ val turnRestrictionTypes = linkedSetOf(
 )
 
 private val maxWeightKeys = MaxWeightType.entries.map { it.osmKey }.toTypedArray()
-
-private val darkerGold = Color(ColorUtils.blendARGB(OverlayColor.Gold.toArgb(), OverlayColor.Black.toArgb(), 0.75f))
-private val darkerOrange = Color(ColorUtils.blendARGB(OverlayColor.Orange.toArgb(), OverlayColor.Black.toArgb(), 0.75f))

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayNode.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayNode.kt
@@ -1,0 +1,125 @@
+package de.westnordost.streetcomplete.overlays.restriction
+
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
+import de.westnordost.streetcomplete.osm.ALL_ROADS
+import de.westnordost.streetcomplete.osm.oneway.isNotOnewayForCyclists
+import de.westnordost.streetcomplete.osm.oneway.isOneway
+import de.westnordost.streetcomplete.util.ktx.firstAndLast
+import de.westnordost.streetcomplete.util.math.PositionOnWay
+import de.westnordost.streetcomplete.util.math.VertexOfWay
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class RestrictionNodeType {
+    GIVE_WAY,
+    STOP,
+    ALL_WAY_STOP,
+}
+
+@Serializable
+enum class RestrictionNodeDirection(val osmValue: String) {
+    FORWARD("forward"),
+    BACKWARD("backward"),
+}
+
+fun parseRestrictionNode(tags: Map<String, String>): Pair<RestrictionNodeType?, RestrictionNodeDirection?> {
+    val type = when {
+        tags["highway"] == "give_way" -> RestrictionNodeType.GIVE_WAY
+        // direction = both seems to be used like stop = all
+        tags["highway"] == "stop" && (tags["stop"] == "all" || tags["direction"] == "both") ->
+            RestrictionNodeType.ALL_WAY_STOP
+        tags["highway"] == "stop" -> RestrictionNodeType.STOP
+        else -> null
+    }
+    val direction = when (type) {
+        RestrictionNodeType.GIVE_WAY, RestrictionNodeType.STOP ->
+            tags["direction"]?.let { dir ->
+                RestrictionNodeDirection.entries.firstOrNull { it.osmValue == dir }
+            }
+        else -> null
+    }
+    return type to direction
+}
+
+fun RestrictionNodeType.applyTo(
+    tagChanges: StringMapChangesBuilder,
+    direction: RestrictionNodeDirection?,
+) {
+    val newDirection = direction?.takeIf { this != RestrictionNodeType.ALL_WAY_STOP }?.osmValue
+    if (tagChanges["direction"] != newDirection) {
+        if (newDirection == null) {
+            tagChanges.remove("direction")
+        } else {
+            tagChanges["direction"] = newDirection
+        }
+    }
+    val newHighway = if (this == RestrictionNodeType.GIVE_WAY) "give_way" else "stop"
+    if (tagChanges["highway"] != newHighway) {
+        tagChanges["highway"] = newHighway
+    }
+    if (this == RestrictionNodeType.ALL_WAY_STOP) {
+        tagChanges["stop"] = "all" // according to wiki, also minor is possible, but it seems that it's not used on intersection nodes
+    } else if (this == RestrictionNodeType.GIVE_WAY) {
+        tagChanges.remove("stop")
+    }
+}
+
+/** Auto-switch stop <-> all-way stop when creating a node, matching the historical form. */
+fun resolveRestrictionNodeType(
+    type: RestrictionNodeType?,
+    wayCountOnVertex: Int?,
+): RestrictionNodeType? = when (type) {
+    RestrictionNodeType.STOP ->
+        if (wayCountOnVertex != null && wayCountOnVertex > 1) RestrictionNodeType.ALL_WAY_STOP else type
+    RestrictionNodeType.ALL_WAY_STOP ->
+        if (wayCountOnVertex == null || wayCountOnVertex == 1) RestrictionNodeType.STOP else type
+    else -> type
+}
+
+fun isOccupiedTrafficControlVertex(tags: Map<String, String>): Boolean =
+    tags.containsKey("highway") || tags.containsKey("crossing")
+
+/** Give-way may not be placed on a vertex shared by more than one eligible way. */
+fun positionOnWayForRestrictionNode(
+    type: RestrictionNodeType?,
+    positionOnWay: PositionOnWay?,
+    wayCountOnVertex: Int?,
+    vertexTags: Map<String, String>?,
+): PositionOnWay? {
+    if (positionOnWay == null) return null
+    if (positionOnWay is VertexOfWay && (vertexTags == null || isOccupiedTrafficControlVertex(vertexTags))) {
+        return null
+    }
+    if (type == RestrictionNodeType.GIVE_WAY && wayCountOnVertex != null && wayCountOnVertex > 1) {
+        return null
+    }
+    return positionOnWay
+}
+
+fun wayCountOnVertex(
+    nodeId: Long,
+    roads: Collection<Pair<Way, *>>,
+): Int {
+    val matching = roads.filter { it.first.nodeIds.contains(nodeId) }
+    return if (matching.size == 2 && matching.all { it.first.nodeIds.firstAndLast().contains(nodeId) }) {
+        1
+    } else {
+        matching.size
+    }
+}
+
+fun shouldShowRestrictionNodeDirection(
+    wayTags: Map<String, String>?,
+    isLeftHandTraffic: Boolean,
+    isMultiWayVertex: Boolean,
+): Boolean {
+    if (isMultiWayVertex) return false
+    val tags = wayTags ?: return false
+    return if (tags["highway"] in ALL_ROADS) {
+        !isOneway(tags) || isNotOnewayForCyclists(tags, isLeftHandTraffic)
+    } else {
+        // cycleways, though doesn't catch oneway = yes and oneway:bicycle = no
+        !isOneway(tags) && tags["oneway:bicycle"] !in listOf("yes", "-1")
+    }
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayNodeForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayNodeForm.kt
@@ -1,378 +1,316 @@
 package de.westnordost.streetcomplete.overlays.restriction
-/*
-import android.content.res.Configuration
-import android.os.Bundle
-import android.view.View
+
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.core.view.doOnLayout
-import de.westnordost.streetcomplete.R
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
+import de.westnordost.streetcomplete.data.meta.CountryInfo
 import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
 import de.westnordost.streetcomplete.data.osm.edits.create.createNodeAction
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
-import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
-import de.westnordost.streetcomplete.databinding.ComposeViewBinding
+import de.westnordost.streetcomplete.data.overlays.Edit
+import de.westnordost.streetcomplete.data.overlays.OverlayAction
 import de.westnordost.streetcomplete.osm.ALL_ROADS
-import de.westnordost.streetcomplete.osm.oneway.isNotOnewayForCyclists
-import de.westnordost.streetcomplete.osm.oneway.isOneway
-import de.westnordost.streetcomplete.overlays.AbstractOverlayForm
 import de.westnordost.streetcomplete.resources.Res
 import de.westnordost.streetcomplete.resources.oneway_yes
 import de.westnordost.streetcomplete.resources.oneway_yes_reverse
-import de.westnordost.streetcomplete.screens.main.bottom_sheet.IsMapOrientationAware
-import de.westnordost.streetcomplete.screens.main.bottom_sheet.IsMapPositionAware
+import de.westnordost.streetcomplete.resources.restriction_overlay_direction_text
 import de.westnordost.streetcomplete.ui.common.DropdownButton
+import de.westnordost.streetcomplete.ui.common.Pin
 import de.westnordost.streetcomplete.ui.common.item_select.ImageWithLabel
+import de.westnordost.streetcomplete.ui.common.overlay.OverlayForm
+import de.westnordost.streetcomplete.ui.common.quest.LocalGetOffsetCallback
+import de.westnordost.streetcomplete.ui.common.quest.LocalMapMetersPerDp
+import de.westnordost.streetcomplete.ui.common.quest.LocalMapRotation
+import de.westnordost.streetcomplete.ui.ktx.pxToDp
 import de.westnordost.streetcomplete.ui.ktx.selectionFrame
+import de.westnordost.streetcomplete.ui.ktx.toPx
 import de.westnordost.streetcomplete.ui.util.ClipCirclePainter
-import de.westnordost.streetcomplete.ui.util.content
-import de.westnordost.streetcomplete.util.ktx.dpToPx
-import de.westnordost.streetcomplete.util.ktx.firstAndLast
 import de.westnordost.streetcomplete.util.math.PositionOnWay
 import de.westnordost.streetcomplete.util.math.PositionOnWaySegment
 import de.westnordost.streetcomplete.util.math.VertexOfWay
 import de.westnordost.streetcomplete.util.math.enclosingBoundingBox
 import de.westnordost.streetcomplete.util.math.getPositionOnWays
 import de.westnordost.streetcomplete.util.math.initialBearingTo
-import org.koin.android.ext.android.inject
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
-class RestrictionOverlayNodeForm : AbstractOverlayForm(), IsMapPositionAware, IsMapOrientationAware {
+private val selectableRestrictionNodeTypes = listOf(
+    RestrictionNodeType.GIVE_WAY,
+    RestrictionNodeType.STOP,
+)
 
-    private val mapDataWithEditsSource: MapDataWithEditsSource by inject()
-    override val contentLayoutResId = R.layout.compose_view
-    private val binding by contentViewBinding(ComposeViewBinding::bind)
-    private val items = Type.entries
-    private val selectableItems = listOf(Type.GIVE_WAY, Type.STOP)
+@Composable
+fun RestrictionOverlayNodeForm(
+    on: (OverlayAction) -> Unit,
+    element: Element?,
+    geometry: ElementGeometry,
+    countryInfo: CountryInfo,
+    mapDataWithEditsSource: MapDataWithEditsSource = koinInject(),
+) {
+    val (originalType, originalDirection) = remember(element) {
+        element?.tags?.let { parseRestrictionNode(it) } ?: (null to null)
+    }
+    var selectedType by rememberSaveable(originalType) {
+        mutableStateOf(originalType)
+    }
+    var direction by rememberSaveable(originalDirection) {
+        mutableStateOf(originalDirection)
+    }
 
-    // state is separate for historic reasons
-    private val positionOnWayState: MutableState<PositionOnWay?> = mutableStateOf(null)
-    private var positionOnWay: PositionOnWay? = null
-        set(value) {
-            field = value
-            if (value != null) {
-                setMarkerPosition(value.position)
-                setMarkerVisibility(true)
-            } else {
-                setMarkerVisibility(false)
-                setMarkerPosition(null)
-            }
-            positionOnWayState.value = value
+    val position = if (element == null) geometry.center else null
+    val roads = remember<Collection<Pair<Way, List<LatLon>>>?>(position != null) {
+        position?.let {
+            mapDataWithEditsSource.getRestrictionNodeWays(it.enclosingBoundingBox(100.0))
         }
-    private var roads: Collection<Pair<Way, List<LatLon>>>? = null
-    private val waysFilter = """
-        ways with
-          area != yes
-          and (
-            highway ~ ${ALL_ROADS.joinToString("|")}|cycleway
-            or (
-              highway ~ path|footpath|bridleway
-              and bicycle ~ yes|designated
-            )
-          )
-    """.toElementFilterExpression()
+    }
+    val metersPerDp = LocalMapMetersPerDp.current
+    val maxDistanceToCrosshair = (metersPerDp * 24).dp.toPx().toDouble()
+    val snapToVertexDistance = (metersPerDp * 12).dp.toPx().toDouble()
 
-    private var data: MapDataWithGeometry? = null
-    private var direction: MutableState<Direction?> = mutableStateOf(null)
+    val rawPositionOnWay = remember(position, roads, metersPerDp) {
+        if (position == null || roads == null) return@remember null
+        position.getPositionOnWays(
+            ways = roads,
+            maxDistance = maxDistanceToCrosshair,
+            snapToVertexDistance = snapToVertexDistance,
+        )
+    }
+    val wayCountOnVertex = remember(rawPositionOnWay, roads) {
+        val vertex = rawPositionOnWay as? VertexOfWay ?: return@remember null
+        val roads = roads ?: return@remember null
+        wayCountOnVertex(vertex.nodeId, roads)
+    }
+    val vertexTags = remember(rawPositionOnWay) {
+        val vertex = rawPositionOnWay as? VertexOfWay ?: return@remember null
+        mapDataWithEditsSource.getNode(vertex.nodeId)?.tags
+    }
 
-    // state is separate for historic reasons
-    private var typeState: MutableState<Type?> = mutableStateOf(null)
-    private var type: Type? = null
-        set(value) {
-            if (field == value) return
-            field = value
-            checkCurrentCursorPosition()
-            if (element == null) {
-                if (type == Type.GIVE_WAY) setMarkerIcon(R.drawable.ic_restriction_give_way)
-                    else setMarkerIcon(R.drawable.ic_restriction_stop)
+    val type = if (element == null) {
+        resolveRestrictionNodeType(selectedType, wayCountOnVertex)
+    } else {
+        selectedType
+    }
+    val positionOnWay = if (element == null) {
+        positionOnWayForRestrictionNode(type, rawPositionOnWay, wayCountOnVertex, vertexTags)
+    } else {
+        null
+    }
+
+    val wayForDirection = remember(element, positionOnWay) {
+        mapDataWithEditsSource.wayForRestrictionNode(element, positionOnWay)
+    }
+    val isMultiWayVertex = (rawPositionOnWay as? VertexOfWay)?.wayIds?.size?.let { it > 1 } == true
+        && element == null
+    val showWayDirection = type != RestrictionNodeType.ALL_WAY_STOP &&
+        shouldShowRestrictionNodeDirection(
+            wayTags = wayForDirection?.tags,
+            isLeftHandTraffic = countryInfo.isLeftHandTraffic,
+            isMultiWayVertex = isMultiWayVertex,
+        )
+    val wayRotation = remember(element, positionOnWay, wayForDirection) {
+        mapDataWithEditsSource.wayRotationForRestrictionNode(element, positionOnWay, wayForDirection)
+    }
+    val mapRotation = LocalMapRotation.current
+    val imageRotation = wayRotation.toFloat() - mapRotation
+
+    val hasChanges = type != originalType || direction != originalDirection
+    val isComplete = type != null && (element != null || positionOnWay != null)
+
+    Box(Modifier.fillMaxSize()) {
+        if (positionOnWay != null) {
+            val offset = LocalGetOffsetCallback.current?.invoke(positionOnWay.position)
+            if (offset != null) {
+                Pin(
+                    iconPainter = painterResource(type?.icon ?: RestrictionNodeType.STOP.icon),
+                    modifier = Modifier
+                        .align(AbsoluteAlignment.TopLeft)
+                        .size(71.dp, 142.dp)
+                        .absoluteOffset(
+                            x = offset.x.pxToDp() - 36.dp,
+                            y = offset.y.pxToDp() - 71.dp
+                        )
+                )
             }
-            checkIsFormComplete()
-            typeState.value = field
         }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        binding.composeViewBase.content { Surface {
-            var shouldShowWayDirection by remember { mutableStateOf(shouldShowWayDirection()) }
-            LaunchedEffect(positionOnWayState.value) {
-                shouldShowWayDirection = shouldShowWayDirection()
-            }
+        OverlayForm(
+            on = on,
+            isComplete = isComplete,
+            hasChanges = hasChanges,
+            onClickOk = {
+                val type = type ?: return@OverlayForm
+                if (element != null) {
+                    val tagChanges = StringMapChangesBuilder(element.tags)
+                    type.applyTo(tagChanges, direction)
+                    if (!tagChanges.hasChanges) return@OverlayForm
+                    on(Edit(UpdateElementTagsAction(element, tagChanges.create())))
+                } else if (positionOnWay != null) {
+                    val action = createNodeAction(positionOnWay, mapDataWithEditsSource) {
+                        type.applyTo(it, direction)
+                    }
+                    if (action != null) {
+                        on(Edit(action))
+                    }
+                }
+            },
+        ) {
             Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-                // Sign selection
                 DropdownButton(
-                    items = selectableItems,
-                    onSelectedItem = { type = it },
-                    selectedItem = typeState.value,
+                    items = selectableRestrictionNodeTypes,
+                    onSelectedItem = { selectedType = it },
+                    selectedItem = type,
                     itemContent = {
                         ImageWithLabel(
-                            painter = painterResource(it.image),
-                            label = stringResource(it.text)
+                            painter = painterResource(it.icon),
+                            label = stringResource(it.title)
                         )
                     }
                 )
 
-                if (typeState.value != Type.ALL_WAY_STOP && shouldShowWayDirection) {
-                    // direction chooser
-                    Text(stringResource(R.string.restriction_overlay_direction_text))
+                if (showWayDirection) {
+                    Text(stringResource(Res.string.restriction_overlay_direction_text))
                     Row {
-                        val yes = org.jetbrains.compose.resources.painterResource(Res.drawable.oneway_yes)
-                        val reverse = org.jetbrains.compose.resources.painterResource(Res.drawable.oneway_yes_reverse)
-                        Box(
-                            modifier = Modifier
-                                .selectionFrame(direction.value == Direction.FORWARD)
-                                .selectable(direction.value == Direction.FORWARD) {
-                                    direction.value = Direction.FORWARD
-                                    checkIsFormComplete()
-                                },
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            ImageWithLabel(
-                                painter = remember(yes) { ClipCirclePainter(yes) },
-                                label = null,
-                                imageRotation = getWayRotation().toFloat() - mapRotation.floatValue,
-                            )
-                        }
-                        Box(
-                            modifier = Modifier
-                                .selectionFrame(direction.value == Direction.BACKWARD)
-                                .selectable(direction.value == Direction.BACKWARD) {
-                                    direction.value = Direction.BACKWARD
-                                    checkIsFormComplete()
-                                },
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            ImageWithLabel(
-                                painter = remember(reverse) { ClipCirclePainter(reverse) },
-                                label = null,
-                                imageRotation = getWayRotation().toFloat() - mapRotation.floatValue
-                            )
-                        }
+                        val forwardPainter = painterResource(Res.drawable.oneway_yes)
+                        val backwardPainter = painterResource(Res.drawable.oneway_yes_reverse)
+                        DirectionChoice(
+                            selected = direction == RestrictionNodeDirection.FORWARD,
+                            painter = remember(forwardPainter) { ClipCirclePainter(forwardPainter) },
+                            imageRotation = imageRotation,
+                            onSelect = { direction = RestrictionNodeDirection.FORWARD },
+                        )
+                        DirectionChoice(
+                            selected = direction == RestrictionNodeDirection.BACKWARD,
+                            painter = remember(backwardPainter) { ClipCirclePainter(backwardPainter) },
+                            imageRotation = imageRotation,
+                            onSelect = { direction = RestrictionNodeDirection.BACKWARD },
+                        )
                     }
                 }
             }
-        } }
-
-        checkIsFormComplete()
-
-        if (savedInstanceState != null) onLoadInstanceState(savedInstanceState)
-
-        if (element == null) {
-            view.doOnLayout {
-                initCreatingPointOnWay()
-                checkCurrentCursorPosition()
-            }
-            setMarkerIcon(R.drawable.ic_restriction_stop)
-            setMarkerVisibility(false)
-        } else {
-            val td = getTypeAndDirection(element!!.tags)
-            type = td.first
-            direction.value = td.second
         }
-    }
-
-    private fun initCreatingPointOnWay() {
-        data = mapDataWithEditsSource.getMapDataWithGeometry(geometry.center.enclosingBoundingBox(100.0))
-        val data = data ?: return
-        roads = data
-            .filter(waysFilter)
-            .filterIsInstance<Way>()
-            .map { way ->
-                val positions = way.nodeIds.map { data.getNode(it)!!.position }
-                way to positions
-            }.toList()
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        checkCurrentCursorPosition()
-    }
-
-    override fun onMapMoved(position: LatLon) {
-        if (element != null) return
-        checkCurrentCursorPosition()
-    }
-
-    private fun shouldShowWayDirection(): Boolean {
-        val element = element
-        val pow = positionOnWay
-        if (pow is VertexOfWay && pow.wayIds.size > 1) return false
-        val way = when {
-            element != null -> mapDataWithEditsSource.getWaysForNode(element.id).firstOrNull { waysFilter.matches(it) }
-            pow is VertexOfWay -> mapDataWithEditsSource.getWay(pow.wayIds.first())
-            pow is PositionOnWaySegment -> mapDataWithEditsSource.getWay(pow.wayId)
-            else -> null
-        }
-        if (way == null) return false
-        return if (way.tags["highway"] in ALL_ROADS)
-            !isOneway(way.tags) || isNotOnewayForCyclists(way.tags, countryInfo.isLeftHandTraffic)
-        else // cycleways, though doesn't catch oneway = yes and oneway:bicycle = no
-            !isOneway(way.tags) && way.tags["oneway:bicycle"] !in listOf("yes", "-1")
-    }
-
-    private fun checkCurrentCursorPosition() {
-        val roads = roads ?: return
-        val metersPerPixel = metersPerPixel ?: return
-        val maxDistance = metersPerPixel * requireContext().resources.dpToPx(24)
-        val snapToVertexDistance = metersPerPixel * requireContext().resources.dpToPx(12)
-        val pos = geometry.center.getPositionOnWays(roads, maxDistance, snapToVertexDistance)
-        if (pos is VertexOfWay) {
-            val node = mapDataWithEditsSource.getNode(pos.nodeId)!!
-            if (node.tags.containsKey("highway") || node.tags.containsKey("crossing"))
-                return
-        }
-        // get number of roads on this vertex
-        // but count only 1 road if count is 2 and it's an end node of both
-        val wayCountOnVertex = if (pos !is VertexOfWay) null
-        else {
-            val r = roads.filter { it.first.nodeIds.contains(pos.nodeId) }
-            if (r.size == 2 && r.all { it.first.nodeIds.firstAndLast().contains(pos.nodeId) }) 1
-            else r.size
-        }
-        positionOnWay = when (type) {
-            Type.GIVE_WAY -> {
-                if (wayCountOnVertex != null && wayCountOnVertex > 1)
-                    null // don't allow on more than a single way
-                else pos
-            }
-            Type.STOP -> {
-                if (wayCountOnVertex != null && wayCountOnVertex > 1)
-                    type = Type.ALL_WAY_STOP // no normal stop if there is more than one way
-                pos
-            }
-            Type.ALL_WAY_STOP -> {
-                if (wayCountOnVertex == null || wayCountOnVertex == 1)
-                    type = Type.STOP // normal stop if there is only one way
-                pos
-            }
-            else -> pos
-        }
-        checkIsFormComplete()
-    }
-
-    override fun hasChanges(): Boolean {
-        val td = element?.let { getTypeAndDirection(it.tags) }
-        return td?.first != type || td?.second != direction.value
-    }
-
-    override fun isFormComplete(): Boolean = type != null && hasChanges() && (element != null || positionOnWay != null)
-
-    override fun onClickOk() {
-        val element = element
-        val positionOnWay = positionOnWay
-        val direction = direction
-        val type = type ?: return
-        val editAction = if (element != null) {
-            val tagChanges = StringMapChangesBuilder(element.tags)
-            applyTo(tagChanges, type, direction.value)
-            UpdateElementTagsAction(element, tagChanges.create())
-        } else if (positionOnWay != null) {
-            createNodeAction(positionOnWay, mapDataWithEditsSource) { applyTo(it, type, direction.value) }
-        } else null
-        if (editAction != null)
-            applyEdit(editAction)
-    }
-
-    private fun onLoadInstanceState(inState: Bundle) {
-        val selectedIndex = inState.getInt(SELECTED_INDEX)
-        type = if (selectedIndex != -1) items[selectedIndex] else null
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putInt(SELECTED_INDEX, items.indexOfFirst { it == type })
-    }
-
-    private fun getWayRotation(): Double {
-        val element = element as? Node
-        if (element != null) {
-            val way = mapDataWithEditsSource.getWaysForNode(element.id).firstOrNull { waysFilter.matches(it) } ?: return 0.0
-            val index = way.nodeIds.indexOf(element.id)
-            return if (index != way.nodeIds.lastIndex)
-                element.position.initialBearingTo(mapDataWithEditsSource.getNode(way.nodeIds[index + 1])!!.position)
-            else
-                mapDataWithEditsSource.getNode(way.nodeIds[index - 1])!!.position.initialBearingTo(element.position)
-        } else {
-            val pow = positionOnWay ?: return 0.0
-            if (pow is PositionOnWaySegment) return pow.segment.first.initialBearingTo(pow.segment.second)
-            else if (pow is VertexOfWay) {
-                val way = mapDataWithEditsSource.getWay(pow.wayIds.first())!!
-                val index = way.nodeIds.indexOf(pow.nodeId)
-                return if (index != way.nodeIds.lastIndex)
-                    pow.position.initialBearingTo(mapDataWithEditsSource.getNode(way.nodeIds[index + 1])!!.position)
-                else
-                    mapDataWithEditsSource.getNode(way.nodeIds[index - 1])!!.position.initialBearingTo(pow.position)
-            }
-        }
-        return 0.0
-    }
-
-    companion object {
-        private const val SELECTED_INDEX = "selected_index"
     }
 }
 
-private fun applyTo(tagChanges: StringMapChangesBuilder, type: Type, direction: Direction?) {
-    val newDirection = direction?.takeIf { type != Type.ALL_WAY_STOP }?.osmValue
-    if (tagChanges["direction"] != newDirection) {
-        if (newDirection == null)
-            tagChanges.remove("direction")
-        else tagChanges["direction"] = newDirection
+@Composable
+private fun DirectionChoice(
+    selected: Boolean,
+    painter: Painter,
+    imageRotation: Float,
+    onSelect: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .selectionFrame(selected)
+            .selectable(selected) { onSelect() },
+        contentAlignment = Alignment.Center,
+    ) {
+        ImageWithLabel(
+            painter = painter,
+            label = null,
+            imageRotation = imageRotation,
+        )
     }
-    val newHighway = if (type == Type.GIVE_WAY) "give_way"
-        else "stop"
-    if (tagChanges["highway"] != newHighway)
-        tagChanges["highway"] = newHighway
-    if (type == Type.ALL_WAY_STOP) tagChanges["stop"] = "all" // according to wiki, also minor is possible, but it seems that it's not used on intersection nodes
-    else if (type == Type.GIVE_WAY) tagChanges.remove("stop")
 }
 
-private fun getTypeAndDirection(tags: Map<String, String>): Pair<Type?, Direction?> {
-    val type = when {
-        tags["highway"] == "give_way" -> Type.GIVE_WAY
-        // direction = both seems to be used like stop = all
-        tags["highway"] == "stop" && (tags["stop"] == "all" || tags["direction"] == "both") -> Type.ALL_WAY_STOP
-        tags["highway"] == "stop" -> Type.STOP
-        else -> null
-    }
-    val direction = when (type) {
-        Type.GIVE_WAY, Type.STOP -> tags["direction"]?.let { dir -> Direction.entries.firstOrNull { it.osmValue == dir } }
-        else -> null
-    }
-    return type to direction
+private val restrictionNodeWaysFilter by lazy { """
+    ways with
+      area != yes
+      and (
+        highway ~ ${ALL_ROADS.joinToString("|")}|cycleway
+        or (
+          highway ~ path|footpath|bridleway
+          and bicycle ~ yes|designated
+        )
+      )
+""".toElementFilterExpression()
 }
 
-private enum class Type { GIVE_WAY, STOP, ALL_WAY_STOP }
-private val Type.text get() = when (this) {
-    Type.GIVE_WAY -> R.string.restriction_overlay_sign_give_way
-    Type.STOP -> R.string.restriction_overlay_sign_stop
-    Type.ALL_WAY_STOP -> R.string.restriction_overlay_sign_stop_all_way
-}
-private val Type.image get() = when (this) {
-    Type.GIVE_WAY -> R.drawable.ic_restriction_give_way
-    Type.STOP -> R.drawable.ic_restriction_stop
-    Type.ALL_WAY_STOP -> R.drawable.ic_restriction_stop
+private fun MapDataWithEditsSource.getRestrictionNodeWays(
+    bbox: BoundingBox,
+): Collection<Pair<Way, List<LatLon>>> {
+    val data = getMapDataWithGeometry(bbox)
+    return data
+        .filter(restrictionNodeWaysFilter)
+        .filterIsInstance<Way>()
+        .map { way ->
+            val positions = way.nodeIds.map { data.getNode(it)!!.position }
+            way to positions
+        }.toList()
 }
 
-private enum class Direction(val osmValue: String) { FORWARD("forward"), BACKWARD("backward") }
-*/
+private fun MapDataWithEditsSource.wayForRestrictionNode(
+    element: Element?,
+    positionOnWay: PositionOnWay?,
+): Way? = when {
+    element != null -> getWaysForNode(element.id).firstOrNull { restrictionNodeWaysFilter.matches(it) }
+    positionOnWay is VertexOfWay -> getWay(positionOnWay.wayIds.first())
+    positionOnWay is PositionOnWaySegment -> getWay(positionOnWay.wayId)
+    else -> null
+}
+
+private fun MapDataWithEditsSource.wayRotationForRestrictionNode(
+    element: Element?,
+    positionOnWay: PositionOnWay?,
+    way: Way?,
+): Double {
+    val node = element as? Node
+    if (node != null) {
+        val way = way ?: return 0.0
+        val index = way.nodeIds.indexOf(node.id)
+        if (index < 0) return 0.0
+        return bearingAlongWayAtIndex(node.position, index, way.nodeIds) { getNode(it)?.position }
+    }
+    return when (positionOnWay) {
+        is PositionOnWaySegment -> positionOnWay.segment.first.initialBearingTo(positionOnWay.segment.second)
+        is VertexOfWay -> {
+            val way = way ?: getWay(positionOnWay.wayIds.first()) ?: return 0.0
+            val index = way.nodeIds.indexOf(positionOnWay.nodeId)
+            if (index < 0) return 0.0
+            bearingAlongWayAtIndex(positionOnWay.position, index, way.nodeIds) { getNode(it)?.position }
+        }
+        else -> 0.0
+    }
+}
+
+internal fun bearingAlongWayAtIndex(
+    position: LatLon,
+    index: Int,
+    nodeIds: List<Long>,
+    positionOf: (Long) -> LatLon?,
+): Double {
+    if (nodeIds.size < 2 || index !in nodeIds.indices) return 0.0
+    return if (index != nodeIds.lastIndex) {
+        val next = positionOf(nodeIds[index + 1]) ?: return 0.0
+        position.initialBearingTo(next)
+    } else {
+        val previous = positionOf(nodeIds[index - 1]) ?: return 0.0
+        previous.initialBearingTo(position)
+    }
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayNodeItem.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayNodeItem.kt
@@ -1,0 +1,22 @@
+package de.westnordost.streetcomplete.overlays.restriction
+
+import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.resources.ic_restriction_give_way
+import de.westnordost.streetcomplete.resources.ic_restriction_stop
+import de.westnordost.streetcomplete.resources.restriction_overlay_sign_give_way
+import de.westnordost.streetcomplete.resources.restriction_overlay_sign_stop
+import de.westnordost.streetcomplete.resources.restriction_overlay_sign_stop_all_way
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.StringResource
+
+val RestrictionNodeType.icon: DrawableResource get() = when (this) {
+    RestrictionNodeType.GIVE_WAY -> Res.drawable.ic_restriction_give_way
+    RestrictionNodeType.STOP,
+    RestrictionNodeType.ALL_WAY_STOP -> Res.drawable.ic_restriction_stop
+}
+
+val RestrictionNodeType.title: StringResource get() = when (this) {
+    RestrictionNodeType.GIVE_WAY -> Res.string.restriction_overlay_sign_give_way
+    RestrictionNodeType.STOP -> Res.string.restriction_overlay_sign_stop
+    RestrictionNodeType.ALL_WAY_STOP -> Res.string.restriction_overlay_sign_stop_all_way
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWay.kt
@@ -1,0 +1,328 @@
+package de.westnordost.streetcomplete.overlays.restriction
+
+import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometryCreator
+import de.westnordost.streetcomplete.data.osm.geometry.ElementPointGeometry
+import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.osm.mapdata.Relation
+import de.westnordost.streetcomplete.data.osm.mapdata.RelationMember
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
+import de.westnordost.streetcomplete.data.osm.mapdata.key
+import de.westnordost.streetcomplete.osm.ALL_ROADS
+import de.westnordost.streetcomplete.quests.max_weight.MaxWeightType
+import de.westnordost.streetcomplete.quests.max_weight.osmKey
+import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.resources.ic_restriction_no_left_turn
+import de.westnordost.streetcomplete.resources.ic_restriction_no_right_turn
+import de.westnordost.streetcomplete.resources.ic_restriction_no_straight_on
+import de.westnordost.streetcomplete.resources.ic_restriction_no_u_turn
+import de.westnordost.streetcomplete.resources.ic_restriction_only_left_turn
+import de.westnordost.streetcomplete.resources.ic_restriction_only_right_turn
+import de.westnordost.streetcomplete.resources.ic_restriction_only_straight_on
+import de.westnordost.streetcomplete.resources.ic_restriction_unknown
+import de.westnordost.streetcomplete.resources.ic_overlay_restriction
+import de.westnordost.streetcomplete.resources.ic_restriction_give_way
+import de.westnordost.streetcomplete.resources.ic_restriction_stop
+import de.westnordost.streetcomplete.util.ktx.containsAny
+import de.westnordost.streetcomplete.util.ktx.firstAndLast
+import de.westnordost.streetcomplete.util.math.distanceToArcs
+import de.westnordost.streetcomplete.util.math.enclosingBoundingBox
+import de.westnordost.streetcomplete.util.math.finalBearingTo
+import kotlinx.serialization.Serializable
+import org.jetbrains.compose.resources.DrawableResource
+
+@Serializable
+sealed interface RestrictionOverlayRestriction {
+    val element: Element
+}
+
+@Serializable
+data class TurnRestriction(val relation: Relation) : RestrictionOverlayRestriction {
+    override val element get() = relation
+}
+
+@Serializable
+data class WeightRestriction(
+    val way: Way,
+    val type: MaxWeightType,
+    val weight: String,
+) : RestrictionOverlayRestriction {
+    override val element get() = way
+}
+
+fun getWeightRestrictions(way: Way): List<WeightRestriction> {
+    val restrictions = mutableListOf<WeightRestriction>()
+    for (type in MaxWeightType.entries) {
+        val key = if (way.tags.containsKey(type.osmKey)) type.osmKey
+            else way.tags.keys.firstOrNull { it == "${type.osmKey}:conditional" } ?: continue
+        val weight = way.tags[key]!!
+        restrictions.add(WeightRestriction(way, type, weight))
+    }
+    return restrictions
+}
+
+fun getOriginalRestrictions(
+    way: Way,
+    mapDataSource: MapDataWithEditsSource,
+): List<RestrictionOverlayRestriction> {
+    val turnRestrictions = mapDataSource.getRelationsForWay(way.id)
+        .filter { it.tags["type"] == "restriction" }
+        .map { TurnRestriction(it) }
+    return turnRestrictions + getWeightRestrictions(way)
+}
+
+fun getInitialRestrictionPreferComplete(
+    restrictions: List<RestrictionOverlayRestriction>,
+    isRelationComplete: (Relation) -> Boolean,
+): RestrictionOverlayRestriction? {
+    restrictions
+        .firstOrNull {
+            it is TurnRestriction
+                && it.relation.isSupportedTurnRestriction()
+                && isRelationComplete(it.relation)
+        }
+        ?.let { return it }
+    restrictions.firstOrNull { it is WeightRestriction }?.let { return it }
+    return restrictions.firstOrNull()
+}
+
+fun getInitialRestriction(
+    restrictions: List<RestrictionOverlayRestriction>,
+): RestrictionOverlayRestriction? =
+    getInitialRestrictionPreferComplete(restrictions) { true }
+
+// restriction:* list from wiki
+val onlyTurnRestriction = listOf(
+    "hgv", "caravan", "motorcar", "bus", "agricultural", "motorcycle", "bicycle", "hazmat"
+)
+
+val onlyTurnRestrictionSet = onlyTurnRestriction.toHashSet()
+
+val turnRestrictionTypeList = turnRestrictionTypes.toList()
+
+fun getIconForTurnRestriction(type: String?): DrawableResource = when (type) {
+    "no_right_turn" -> Res.drawable.ic_restriction_no_right_turn
+    "no_left_turn" -> Res.drawable.ic_restriction_no_left_turn
+    "no_u_turn" -> Res.drawable.ic_restriction_no_u_turn
+    "no_straight_on" -> Res.drawable.ic_restriction_no_straight_on
+    "only_right_turn" -> Res.drawable.ic_restriction_only_right_turn
+    "only_left_turn" -> Res.drawable.ic_restriction_only_left_turn
+    "only_straight_on" -> Res.drawable.ic_restriction_only_straight_on
+    else -> Res.drawable.ic_restriction_unknown
+}
+
+/** Compose drawables that Android MapLibre (overlay layer + geometry markers) must resolve. */
+fun restrictionOverlayAndroidMapIcons(): List<DrawableResource> = buildList {
+    add(Res.drawable.ic_overlay_restriction)
+    add(Res.drawable.ic_restriction_stop)
+    add(Res.drawable.ic_restriction_give_way)
+    for (type in turnRestrictionTypeList) {
+        add(getIconForTurnRestriction(type))
+    }
+    add(getIconForTurnRestriction(null))
+}
+
+fun Map<String, String>.getShortRestrictionValue(): String? {
+    get("restriction")?.let { return it }
+    get("restriction:conditional")?.let { return it.substringBefore("@").trim() }
+    entries.firstOrNull { it.key.startsWith("restriction:") }
+        ?.let { return it.value.substringBefore("@").trim() }
+    return null
+}
+
+/** Find a valid neighboring "to" way for creating a turn restriction from [fromWay]. */
+fun findEligibleToWay(
+    position: LatLon,
+    clickAreaSizeInMeters: Double,
+    fromWay: Way,
+    mapDataSource: MapDataWithEditsSource,
+): Pair<Way, Node>? {
+    val bbox = position.enclosingBoundingBox(clickAreaSizeInMeters.coerceAtLeast(10.0))
+    val data = mapDataSource.getMapDataWithGeometry(bbox)
+
+    val firstAndLastNodes = fromWay.nodeIds.firstAndLast().sorted().filter {
+        mapDataSource.getWaysForNode(it).count { way -> way.tags["highway"] in ALL_ROADS } > 2
+    }
+    if (firstAndLastNodes.isEmpty()) return null
+
+    val eligibleWays = data.ways.mapNotNull { way ->
+        if (way.id == fromWay.id || way.isClosed) return@mapNotNull null
+        if (way.tags["highway"] !in ALL_ROADS) return@mapNotNull null
+        val fl = way.nodeIds.firstAndLast()
+        if (!fl.containsAny(firstAndLastNodes)) return@mapNotNull null
+        val geometry = data.getWayGeometry(way.id) as? ElementPolylinesGeometry ?: return@mapNotNull null
+        way to geometry
+    }
+
+    val otherWay = eligibleWays.minByOrNull {
+        position.distanceToArcs(it.second.polylines.single())
+    }?.first ?: return null
+
+    val viaNodeId = otherWay.nodeIds.firstAndLast()
+        .singleOrNull { it in firstAndLastNodes }
+        ?: return null
+    val viaNode = mapDataSource.getNode(viaNodeId) ?: return null
+    return otherWay to viaNode
+}
+
+fun createTurnRestrictionRelation(
+    fromWay: Way,
+    toWay: Way,
+    viaNode: Node,
+    restrictionType: String,
+    signed: Boolean,
+    baseTags: Map<String, String> = emptyMap(),
+): Relation {
+    val newTags = baseTags.toMutableMap()
+    newTags["type"] = "restriction"
+    // Historical create path wrote explicit=yes when the "signed" switch was unchecked
+    if (!signed) newTags["explicit"] = "yes" else newTags.remove("explicit")
+    newTags["restriction"] = restrictionType
+    return Relation(
+        id = 0L,
+        members = listOf(
+            RelationMember(fromWay.type, fromWay.id, "from"),
+            RelationMember(toWay.type, toWay.id, "to"),
+            RelationMember(viaNode.type, viaNode.id, "via"),
+        ),
+        tags = newTags,
+    )
+}
+
+fun withTurnRestrictionType(relation: Relation, type: String): Relation {
+    val newTags = relation.tags.toMutableMap()
+    val conditionalKey = if (newTags.containsKey("restriction:conditional")) {
+        "restriction:conditional"
+    } else {
+        newTags.keys.firstOrNull { it.startsWith("restriction:") && it.endsWith(":conditional") }
+    }
+    if (conditionalKey != null && !newTags.containsKey(conditionalKey.substringBefore(":conditional"))) {
+        val old = newTags[conditionalKey]!!.substringBefore("@").trim()
+        newTags[conditionalKey] = newTags[conditionalKey]!!.replace(old, type)
+    } else {
+        if (newTags.containsKey("restriction")) {
+            newTags["restriction"] = type
+        } else {
+            val k = newTags.keys.firstOrNull { key ->
+                key.startsWith("restriction:") && onlyTurnRestriction.any { key.endsWith(it) }
+            } ?: "restriction"
+            newTags[k] = type
+        }
+    }
+    return relation.copy(tags = newTags)
+}
+
+fun withImplicitSigned(relation: Relation, signed: Boolean): Relation {
+    val newTags = relation.tags.toMutableMap()
+    if (signed) {
+        newTags.remove("implicit")
+    } else {
+        newTags["implicit"] = "yes"
+    }
+    return relation.copy(tags = newTags)
+}
+
+fun withSwappedFromTo(relation: Relation): Relation {
+    val newMembers = relation.members.map {
+        when (it.role) {
+            "from" -> it.copy(role = "to")
+            "to" -> it.copy(role = "from")
+            else -> it
+        }
+    }
+    return relation.copy(members = newMembers)
+}
+
+fun withExceptions(relation: Relation, exceptions: List<String>): Relation {
+    val newTags = relation.tags.toMutableMap()
+    val value = exceptions.joinToString(";")
+    if (value.isEmpty()) newTags.remove("except") else newTags["except"] = value
+    return relation.copy(tags = newTags)
+}
+
+fun withOnlyFor(relation: Relation, onlyFor: String?): Relation {
+    val currentOnly = relation.tags.keys
+        .firstOrNull {
+            it.startsWith("restriction")
+                && it.substringAfter("restriction:").substringBefore(":conditional") in onlyTurnRestriction
+        }
+    val newTags = relation.tags.toMutableMap()
+    val switchFrom = currentOnly?.let { ":${it.substringAfter("restriction:").substringBefore(":conditional")}" } ?: ""
+    if (onlyFor == null) {
+        newTags.remove("restriction$switchFrom")?.let { newTags["restriction"] = it }
+        newTags.remove("restriction$switchFrom:conditional")?.let { newTags["restriction:conditional"] = it }
+    } else {
+        newTags.remove("restriction$switchFrom")?.let { newTags["restriction:$onlyFor"] = it }
+        newTags.remove("restriction$switchFrom:conditional")?.let { newTags["restriction:$onlyFor:conditional"] = it }
+        // if neither key existed, still set restriction:onlyFor from restriction
+        if (!newTags.containsKey("restriction:$onlyFor") && !newTags.containsKey("restriction:$onlyFor:conditional")) {
+            newTags.remove("restriction")?.let { newTags["restriction:$onlyFor"] = it }
+            newTags.remove("restriction:conditional")?.let { newTags["restriction:$onlyFor:conditional"] = it }
+        }
+    }
+    return relation.copy(tags = newTags)
+}
+
+fun currentOnlyFor(relation: Relation): String? =
+    relation.tags.keys
+        .firstOrNull {
+            it.startsWith("restriction")
+                && it.substringAfter("restriction:").substringBefore(":conditional") in onlyTurnRestriction
+        }
+        ?.substringAfter("restriction:")
+        ?.substringBefore(":conditional")
+
+fun viaBearingForTurnRestriction(
+    relation: Relation,
+    mapDataSource: MapDataWithEditsSource,
+): Pair<LatLon, Double>? {
+    val members = relation.members.map { it.role to (mapDataSource.get(it.type, it.ref) ?: return null) }
+    val viaMembers = members.filter { it.first == "via" }.map { it.second }
+    val from = members.singleOrNull { it.first == "from" }?.second as? Way ?: return null
+    val isFirst = viaMembers.any {
+        it is Node && it.id == from.nodeIds.first()
+            || it is Way && it.nodeIds.firstAndLast().contains(from.nodeIds.first())
+    }
+    val isLast = viaMembers.any {
+        it is Node && it.id == from.nodeIds.last()
+            || it is Way && it.nodeIds.firstAndLast().contains(from.nodeIds.last())
+    }
+    if (isFirst == isLast) return null
+    val nodeIdsForBearing = if (isFirst) from.nodeIds.take(2).reversed() else from.nodeIds.takeLast(2)
+    val nodesForBearing = nodeIdsForBearing.map { mapDataSource.getNode(it) ?: return null }
+    val bearing = nodesForBearing.first().position.finalBearingTo(nodesForBearing.last().position)
+    return nodesForBearing.last().position to bearing
+}
+
+fun relationGeometry(
+    relation: Relation,
+    mapDataSource: MapDataWithEditsSource,
+): ElementGeometry? {
+    if (relation.id != 0L) {
+        return mapDataSource.getGeometry(relation.type, relation.id)
+    }
+    val ways = relation.members.mapNotNull { if (it.type == ElementType.WAY) it.key else null }
+    val geometries = mapDataSource.getGeometries(ways)
+        .associate {
+            it.elementId to (it.geometry as? ElementPolylinesGeometry)?.polylines?.singleOrNull()
+        }
+        .filterValues { it != null }
+        .mapValues { it.value!! }
+    if (geometries.isEmpty()) return null
+    return ElementGeometryCreator().create(relation, geometries)
+}
+
+fun isRelationComplete(relation: Relation, mapDataSource: MapDataWithEditsSource): Boolean =
+    relation.members.all { mapDataSource.get(it.type, it.ref) != null }
+
+/** Exception vehicle types historically offered in the multi-choice dialog. */
+val turnRestrictionExceptions = listOf(
+    "bicycle", "psv", "bus", "emergency", "agricultural", "hgv", "moped", "destination", "motorcar"
+)
+
+fun pointGeometry(position: LatLon): ElementPointGeometry = ElementPointGeometry(position)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWay.kt
@@ -238,6 +238,13 @@ fun withSwappedFromTo(relation: Relation): Relation {
     return relation.copy(members = newMembers)
 }
 
+/** Historical UI only enabled from/to swap for newly created draft relations (id == 0). */
+fun isTurnRestrictionFromToSwapAllowed(relation: Relation): Boolean =
+    relation.id == 0L
+
+fun wayRoleInTurnRestriction(relation: Relation, wayId: Long): String? =
+    relation.members.firstOrNull { it.type == ElementType.WAY && it.ref == wayId }?.role
+
 fun withExceptions(relation: Relation, exceptions: List<String>): Relation {
     val newTags = relation.tags.toMutableMap()
     val value = exceptions.joinToString(";")

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWayForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWayForm.kt
@@ -123,7 +123,6 @@ fun RestrictionOverlayWayForm(
     }
 
     var turnRestrictionSelectionMode by rememberSaveable { mutableStateOf(false) }
-    var canSwapFromTo by rememberSaveable { mutableStateOf(false) }
     var draftSigned by rememberSaveable {
         mutableStateOf(
             (selectedRestriction as? TurnRestriction)?.relation?.tags?.get("implicit") != "yes"
@@ -169,7 +168,6 @@ fun RestrictionOverlayWayForm(
     fun selectRestriction(restriction: RestrictionOverlayRestriction) {
         selectedRestriction = restriction
         currentRestriction = restriction
-        canSwapFromTo = false
         turnRestrictionSelectionMode = false
         if (restriction is WeightRestriction) {
             editedWeight = parseWeight(restriction.weight, units)
@@ -215,11 +213,13 @@ fun RestrictionOverlayWayForm(
             baseTags = baseTags,
         )
         currentRestriction = TurnRestriction(relation)
-        canSwapFromTo = true
         turnRestrictionSelectionMode = false
     }
 
-    LaunchedEffect(currentRestriction, draftTurnType, wayGeometry, turnRestrictionSelectionMode) {
+    // Include member roles so from<->to swap refreshes via bearing / highlights.
+    val turnMemberRoles = (currentRestriction as? TurnRestriction)
+        ?.relation?.members?.joinToString { "${it.role}:${it.type}:${it.ref}" }
+    LaunchedEffect(currentRestriction, turnMemberRoles, draftTurnType, wayGeometry, turnRestrictionSelectionMode) {
         if (turnRestrictionSelectionMode) {
             mapMarkersCallback?.invoke(listOf(Marker(wayGeometry)))
             return@LaunchedEffect
@@ -310,9 +310,9 @@ fun RestrictionOverlayWayForm(
                 turnRestrictionSelectionMode -> {
                     TurnRestrictionEditor(
                         relation = (currentRestriction as? TurnRestriction)?.relation,
+                        wayId = way.id,
                         draftTurnType = draftTurnType,
                         draftSigned = draftSigned,
-                        canSwapFromTo = false,
                         selectionMode = true,
                         onTurnTypeChange = { draftTurnType = it },
                         onSignedChange = { draftSigned = it },
@@ -337,32 +337,38 @@ fun RestrictionOverlayWayForm(
                             .joinToString("\n")
                         TurnRestrictionEditor(
                             relation = turn.relation,
+                            wayId = way.id,
                             draftTurnType = draftTurnType,
                             draftSigned = draftSigned,
-                            canSwapFromTo = canSwapFromTo || turn.relation.id == 0L,
                             selectionMode = false,
                             onTurnTypeChange = { type ->
                                 draftTurnType = type
+                                val latest = (currentRestriction as? TurnRestriction)?.relation
+                                    ?: turn.relation
                                 currentRestriction = TurnRestriction(
-                                    withTurnRestrictionType(turn.relation, type)
+                                    withTurnRestrictionType(latest, type)
                                 )
                             },
                             onSignedChange = { signed ->
                                 draftSigned = signed
+                                val latest = (currentRestriction as? TurnRestriction)?.relation
+                                    ?: turn.relation
                                 currentRestriction = TurnRestriction(
-                                    withImplicitSigned(turn.relation, signed)
+                                    withImplicitSigned(latest, signed)
                                 )
                             },
                             onSwap = {
-                                currentRestriction = TurnRestriction(
-                                    withSwappedFromTo(turn.relation)
-                                )
+                                val latest = (currentRestriction as? TurnRestriction)?.relation
+                                    ?: return@TurnRestrictionEditor
+                                if (!isTurnRestrictionFromToSwapAllowed(latest)) return@TurnRestrictionEditor
+                                currentRestriction = TurnRestriction(withSwappedFromTo(latest))
                             },
                             onExceptionsClick = { showExceptionsDialog = true },
                             onOnlyForClick = { showOnlyForDialog = true },
                             onConditionalClick = {
+                                val latestTurn = currentRestriction as? TurnRestriction ?: turn
                                 if (infoText.isNotBlank()) {
-                                    currentRestriction = removeConditional(turn)
+                                    currentRestriction = removeConditional(latestTurn)
                                 } else {
                                     showAddConditionalDialog = true
                                 }
@@ -461,7 +467,6 @@ fun RestrictionOverlayWayForm(
                         turnRestrictionSelectionMode = true
                         draftSigned = true
                         draftTurnType = turnRestrictionTypeList.first()
-                        canSwapFromTo = false
                     }
                     RestrictionType.WEIGHT -> showWeightTypeDialog = true
                 }
@@ -715,9 +720,9 @@ private fun OtherRestrictionsList(
 @Composable
 private fun TurnRestrictionEditor(
     relation: Relation?,
+    wayId: Long,
     draftTurnType: String,
     draftSigned: Boolean,
-    canSwapFromTo: Boolean,
     selectionMode: Boolean,
     onTurnTypeChange: (String) -> Unit,
     onSignedChange: (Boolean) -> Unit,
@@ -732,6 +737,8 @@ private fun TurnRestrictionEditor(
     val selectedType = relation?.tags?.getShortRestrictionValue()
         ?.takeIf { it in turnRestrictionTypeList }
         ?: draftTurnType
+    val canSwap = relation != null && isTurnRestrictionFromToSwapAllowed(relation)
+    val wayRole = relation?.let { wayRoleInTurnRestriction(it, wayId) }
 
     DropdownButton(
         items = turnRestrictionTypeList,
@@ -764,6 +771,14 @@ private fun TurnRestrictionEditor(
     }
 
     if (!selectionMode && relation != null) {
+        if (wayRole != null) {
+            Text(
+                text = wayRole,
+                style = MaterialTheme.typography.subtitle1,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+
         val exceptionsArgs = relation.tags["except"]?.replace(";", ", ")
             ?: stringResource(Res.string.overlay_none)
         Button2(onClick = onExceptionsClick, style = ButtonStyle.Outlined) {
@@ -777,9 +792,10 @@ private fun TurnRestrictionEditor(
             }
         }
 
-        if (canSwapFromTo && relation.id == 0L) {
+        // Historical: swap control only for new draft relations (id == 0), not existing ones
+        if (canSwap) {
             Button2(onClick = onSwap, style = ButtonStyle.Outlined) {
-                Text("from ↔ to")
+                Text("from <-> to")
             }
         }
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWayForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWayForm.kt
@@ -1,688 +1,1005 @@
 package de.westnordost.streetcomplete.overlays.restriction
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.Checkbox
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.unit.dp
+import com.cheonjaeung.compose.grid.SimpleGridCells
+import de.westnordost.streetcomplete.data.meta.CountryInfo
+import de.westnordost.streetcomplete.data.meta.WeightMeasurementUnit
+import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
+import de.westnordost.streetcomplete.data.osm.edits.create.CreateRelationAction
+import de.westnordost.streetcomplete.data.osm.edits.delete.DeleteRelationAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.UpdateElementTagsAction
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.createChanges
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.data.osm.mapdata.Relation
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
+import de.westnordost.streetcomplete.data.overlays.Action
+import de.westnordost.streetcomplete.data.overlays.Edit
+import de.westnordost.streetcomplete.data.overlays.OverlayAction
+import de.westnordost.streetcomplete.osm.AddConditionalDialog
+import de.westnordost.streetcomplete.quests.max_weight.MaxWeightSignForm
+import de.westnordost.streetcomplete.quests.max_weight.MaxWeightType
+import de.westnordost.streetcomplete.quests.max_weight.Weight
+import de.westnordost.streetcomplete.quests.max_weight.getIcon
+import de.westnordost.streetcomplete.quests.max_weight.osmKey
 import de.westnordost.streetcomplete.resources.Res
-import de.westnordost.streetcomplete.resources.*
-
-// todo: is weight form now compose?
-/*
-// todo
-//  save instance state
-//   save selection mode, selected restriction, current restriction
-//  show anything if there is no restriction? looks awfully empty
-//  more restriction types like oneway, length, height
-//  don't allow adding turn restriction if none can be added (much work for little gain)
-//  allow setting via ways, and allow choosing via node if from and to are the same
-//   often needed for no_u_turn, but might be much work
-//  allow adding conditional-only restriction for weight (works for turn only)
-//  form grows too high with many restrictions (maybe scrollview?)
-class RestrictionOverlayWayForm : AbstractOverlayForm() {
-
-    private val mapDataSource: MapDataWithEditsSource by inject()
-    private val mapFragment by lazy {
-        (activity as? MainActivity)?.supportFragmentManager?.fragments?.filterIsInstance<MainMapFragment>()?.singleOrNull()
-    }
-    override val contentLayoutResId = R.layout.fragment_overlay_restriction_way
-    private val binding by contentViewBinding(FragmentOverlayRestrictionWayBinding::bind)
-    private val maxWeightInput: EditText? get() = binding.maxWeightContainer.findViewById(R.id.maxWeightInput)
-    private val weightUnitSelect: Spinner? get() = binding.maxWeightContainer.findViewById(R.id.weightUnitSelect)
-
-    private val originalRestrictions by lazy {
-        val turnRestrictions = mapDataSource.getRelationsForWay(element!!.id).filter { it.tags["type"] == "restriction" }
-            .map { TurnRestriction(it) }
-        val weightRestrictions = getWeightRestrictions(element as Way)
-        turnRestrictions + weightRestrictions
-    }
-
-    // unchanged restriction from originalRestrictions
-    private var selectedRestriction: Restriction? = null
-        set(value) {
-            field = value
-            showOtherRestrictionsList()
-            if (value != null)
-                currentRestriction = value
-        }
-
-    // (currently) can't be set to null
-    private var currentRestriction: Restriction? = null
-        set(value) {
-            if (field == value) return
-            val oldValue = field
-            field = value
-            checkIsFormComplete()
-            // can't add restriction if sth is changed
-            if (field != selectedRestriction)
-                binding.addRestriction.isGone = true
-            when (value) {
-                is WeightRestriction -> {
-                    if (oldValue is WeightRestriction && oldValue.way == value.way && oldValue.sign == value.sign)
-                        // no need to change form if only weight changed
-                        // especially reloading the input while typing is annoying!
-                        return
-                    showWeightRestrictionUi(value)
-                    via = null
-                    mapFragment?.highlightGeometry(geometry)
-                }
-                is TurnRestriction -> {
-                    if (value.relation.isSupportedTurnRestriction()) {
-                        showFullTurnRestrictionUi(value)
-                        showTurnRestrictionOnMap(value)
-                    } else {
-                        showUnsupportedTurnRestriction(value)
-                    }
-                    getGeometry(value.relation)?.let { mapFragment?.highlightGeometry(it) }
-                }
-                null -> { } // should not happen
-            }
-            binding.conditionalButton.isVisible = true
-            if (value is TurnRestriction && value.relation.id == 0L)
-                binding.removeRestriction.isInvisible = true
-            else binding.removeRestriction.isVisible = true
-        }
-
-    // only used for turn restriction
-    private var via: Pair<LatLon, Double>? = null
-        set(value) {
-            field?.first?.let { mapFragment?.deleteMarkerForCurrentHighlighting(ElementPointGeometry(it)) }
-            field = value
-            val tags = (currentRestriction as? TurnRestriction)?.relation?.tags ?: emptyMap()
-            val icon = getIconForTurnRestriction(tags.getShortRestrictionValue() ?: "")
-            value?.let { mapFragment?.putMarkersForCurrentHighlighting(listOf(Marker(ElementPointGeometry(it.first), icon, null, null, it.second))) }
-        }
-
-    // enabled when adding turn restriction, cannot be disabled
-    private var turnRestrictionSelectionMode: Boolean = false
-        set(value) {
-            field = value
-            if (value) {
-                mapFragment?.hideOverlay()
-                mapFragment?.highlightGeometry(geometry) // highlight initially selected way only
-                binding.turnRestrictionContainer.isVisible = true
-                binding.maxWeightContainer.isGone = true
-                binding.exceptions.text = getString(R.string.restriction_overlay_exceptions, getString(R.string.overlay_none))
-                binding.infoText.setText(R.string.restriction_overlay_select_way)
-                binding.infoText.isVisible = true
-                binding.addRestriction.isGone = true
-            }
-        }
-
-    override val otherAnswers get() = listOfNotNull(
-        relationDetailsAnswer(),
-    )
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        lifecycleScope.launch { originalRestrictions } // load restrictions in background, so ui thread needs to wait less
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        if (originalRestrictions.isNotEmpty() && selectedRestriction == null) {
-            selectedRestriction = getInitialRestriction()
-        }
-        binding.addRestriction.setOnClickListener { onClickAddRestriction() }
-
-        binding.turnRestrictionTypeSpinner.adapter = ArrayImageAdapter(requireContext(), turnRestrictionTypeList.map { getIconForTurnRestriction(it) }, 80)
-        binding.turnRestrictionTypeSpinner.onItemSelectedListener = object : OnItemSelectedListener {
-            override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
-                val oldRestriction = currentRestriction as? TurnRestriction ?: return
-                val newTags = oldRestriction.relation.tags.toMutableMap()
-                val conditionalKey = if (newTags.containsKey("restriction:conditional")) "restriction:conditional"
-                    else newTags.keys.firstOrNull { it.startsWith("restriction:") && it.endsWith(":conditional") }
-                if (conditionalKey != null && !newTags.containsKey(conditionalKey.substringBefore(":conditional"))) {
-                    val old = newTags[conditionalKey]!!.substringBefore("@").trim()
-                    newTags[conditionalKey] = newTags[conditionalKey]!!.replace(old, turnRestrictionTypeList[p2])
-                } else {
-                    if (newTags.containsKey("restriction"))
-                        newTags["restriction"] = turnRestrictionTypeList[p2]
-                    else {
-                        val k = newTags.keys.firstOrNull { key -> key.startsWith("restriction:") && onlyTurnRestriction.any { key.endsWith(it) } }
-                            ?: "restriction"
-                        newTags[k] = turnRestrictionTypeList[p2]
-                    }
-                }
-                if (newTags != oldRestriction.relation.tags)
-                    currentRestriction = TurnRestriction(oldRestriction.relation.copy(tags = newTags))
-            }
-            override fun onNothingSelected(p0: AdapterView<*>?) { }
-        }
-        binding.implicitSwitch.isChecked = true
-        binding.removeRestriction.setOnClickListener { onClickedDelete() }
-    }
-
-    private fun getInitialRestriction(): Restriction? {
-        // prefer supported and complete turn restrictions
-        originalRestrictions
-            .firstOrNull { it is TurnRestriction && it.relation.isSupportedTurnRestriction() && it.relation.isRelationComplete() }
-            ?.let { return it }
-
-        // then weight restriction
-        originalRestrictions.firstOrNull { it is WeightRestriction }?.let { return it }
-
-        // just take the first one
-        return originalRestrictions.firstOrNull()
-    }
-
-    private fun showOtherRestrictionsList() {
-        val restrictions = originalRestrictions.filterNot { it == selectedRestriction }
-        if (restrictions.isEmpty()) return // if we show it once, no need to hide again
-        binding.otherRestrictions.isVisible = true
-        binding.otherRestrictions.removeAllViews()
-        binding.otherRestrictions.addView(TextView(requireContext()).apply {
-            setText(R.string.restriction_overlay_other_restrictions)
-        })
-        for (restriction in restrictions) {
-            binding.otherRestrictions.addView(Button(requireContext()).apply {
-                text = when (restriction) {
-                    is TurnRestriction -> restriction.relation.members.filter { it.type == ElementType.WAY && it.ref == element!!.id }
-                        .joinToString(", ") { it.role }
-                    is WeightRestriction -> restriction.weight
-                }
-                val drawable = restriction.getDrawable(layoutInflater, countryInfo)
-                val height = context.resources.dpToPx(56).toInt()
-                val resizedDrawable = drawable
-                    ?.createBitmap(height, drawable.intrinsicWidth * height / drawable.intrinsicHeight)
-                    ?.toDrawable(context.resources)
-
-                setCompoundDrawablesWithIntrinsicBounds(resizedDrawable, null, null, null)
-                setOnClickListener { selectedRestriction = restriction }
-            })
-        }
-    }
-
-    override fun hasChanges(): Boolean =
-        currentRestriction != null && currentRestriction != selectedRestriction
-
-    override fun isFormComplete(): Boolean {
-        val restriction = currentRestriction ?: return false
-        if (!hasChanges()) return false
-        if (restriction is WeightRestriction && restriction.weight.replace(',', '.').toDoubleOrNull() == null) return false
-        return true
-    }
-
-    override fun onClickOk() {
-        val restriction = currentRestriction ?: return
-        when (restriction) {
-            is WeightRestriction -> {
-                val input = restriction.weight.replace(',', '.').toDouble()
-                val weight = when (countryInfo.weightLimitUnits[weightUnitSelect?.selectedItemPosition ?: 0]) {
-                    WeightMeasurementUnit.SHORT_TON  -> ShortTons(input)
-                    WeightMeasurementUnit.POUND      -> ImperialPounds(input.toInt())
-                    WeightMeasurementUnit.METRIC_TON -> MetricTons(input)
-                }
-                val changes = restriction.way.tags.createChanges(element!!.tags)
-                changes[restriction.sign.osmKey] = weight.toString()
-                applyEdit(UpdateElementTagsAction(restriction.way, changes.create()))
-            }
-            is TurnRestriction -> {
-                val rel = restriction.relation
-                val geometry = getGeometry(rel) ?: geometry
-                if (rel.id == 0L) {
-                    applyEdit(CreateRelationAction(rel.tags, rel.members), geometry)
-                } else {
-                    val oldRelation = (selectedRestriction as? TurnRestriction)?.relation ?: return
-                    applyEdit(UpdateElementTagsAction(oldRelation, rel.tags.createChanges(oldRelation.tags).create()), geometry)
-                }
-            }
-        }
-    }
-
-    override fun onClickMapAt(position: LatLon, clickAreaSizeInMeters: Double): Boolean {
-        if (!turnRestrictionSelectionMode) return false
-        val bbox = position.enclosingBoundingBox(clickAreaSizeInMeters.coerceAtLeast(10.0))
-        val data = mapDataSource.getMapDataWithGeometry(bbox)
-        val initialWay = element as Way // this must be correct
-
-        // first and last nodes, but only if they are shared by at least 3 roads (otherwise a restriction doesn't make sense)
-        val firstAndLastNodes = initialWay.nodeIds.firstAndLast().sorted().filter { mapDataSource.getWaysForNode(it).count { it.tags["highway"] in ALL_ROADS } > 2 }
-        if (firstAndLastNodes.isEmpty()) return true
-        val eligibleWays = data.ways.mapNotNull {
-            if (it.id == initialWay.id || it.isClosed) return@mapNotNull null
-            if (it.tags["highway"] !in ALL_ROADS) return@mapNotNull null
-            val fl = it.nodeIds.firstAndLast() // exactly one of first and last nodes need to be shared
-            if (!fl.containsAny(firstAndLastNodes)) return@mapNotNull null
-            val geometry = data.getWayGeometry(it.id) as? ElementPolylinesGeometry ?: return@mapNotNull null
-            it to geometry
-        }
-
-        val otherWay = eligibleWays.minByOrNull { position.distanceToArcs(it.second.polylines.single()) }?.first ?: return true
-        val initialWayAsMember = RelationMember(initialWay.type, initialWay.id, "from")
-        val otherWayAsMember = RelationMember(otherWay.type, otherWay.id, "to")
-        // ignore ways that have same start and end points
-        val viaNode = otherWay.nodeIds.firstAndLast().singleOrNull { it in firstAndLastNodes }?.let { mapDataSource.getNode(it) } ?: return true
-        val viaNodeAsMember = RelationMember(viaNode.type, viaNode.id, "via")
-        val newTags = (currentRestriction as? TurnRestriction)?.relation?.tags?.toMutableMap() ?: mutableMapOf()
-        newTags["type"] = "restriction"
-        if (!binding.implicitSwitch.isChecked)
-            newTags["explicit"] = "yes"
-        newTags["restriction"] = turnRestrictionTypeList[binding.turnRestrictionTypeSpinner.selectedItemPosition]
-        val newRelation = Relation(0L, listOf(initialWayAsMember, otherWayAsMember, viaNodeAsMember), newTags)
-        binding.swapFromToRoles.isVisible = true
-        currentRestriction = TurnRestriction(newRelation)
-        return true
-    }
-
-    private fun onClickAddRestriction() {
-        val res = listOf(
-            Item2(RestrictionType.TURN, ResImage(R.drawable.ic_overlay_restriction)),
-            Item2(RestrictionType.WEIGHT, ResImage(R.drawable.ic_quest_max_weight)),
-        )
-        ImageListPickerDialog(requireContext(), res) {
-            when (it.value) {
-                RestrictionType.TURN -> turnRestrictionSelectionMode = true
-                RestrictionType.WEIGHT -> {
-                    val items = MaxWeightSign.entries.mapNotNull { sign ->
-                        if (originalRestrictions.any { it is WeightRestriction && it.sign == sign })
-                                null
-                            else sign.asItem(layoutInflater, countryInfo.countryCode)
-                    }
-                    ImageListPickerDialog(requireContext(), items) { sign ->
-                        currentRestriction = WeightRestriction(element as Way, sign.value!!, "")
-                        val units = countryInfo.weightLimitUnits.map { it.displayString }
-                        weightUnitSelect?.adapter = ArrayAdapter(requireContext(), R.layout.spinner_item_centered, units)
-                        weightUnitSelect?.setSelection(0)
-
-                        viewLifecycleScope.launch {
-                            delay(20)
-                            maxWeightInput?.requestFocus()
-                            maxWeightInput?.showKeyboard()
-                        }
-                    }.show()
-                }
-                null -> { }
-            }
-        }.show()
-    }
-
-    private fun displayConditionalRestrictions(text: String) {
-        if (text.isNotBlank()) {
-            binding.infoText.text = text
-            binding.infoText.isVisible = true
-            binding.conditionalButton.setText(R.string.restriction_overlay_remove_conditional_restrictions)
-            binding.conditionalButton.setOnClickListener { onClickRemoveConditional() }
-        } else {
-            binding.infoText.isGone = true
-            binding.conditionalButton.setOnClickListener { onClickAddConditional() }
-            binding.conditionalButton.setText(R.string.access_manager_button_add_conditional)
-        }
-    }
-
-    private fun onClickRemoveConditional() {
-        val restriction = currentRestriction ?: return
-        when (restriction) {
-            is TurnRestriction -> {
-                val newTags = restriction.relation.tags.toMutableMap()
-                val oldConditionalKey = if (newTags.containsKey("restriction:conditional")) "restriction:conditional"
-                    else newTags.keys.firstOrNull { it.startsWith("restriction:") && it.endsWith(":conditional") } ?: "restriction:conditional"
-                if (!newTags.containsKey(oldConditionalKey.substringBefore(":conditional")))
-                    newTags[oldConditionalKey.substringBefore(":conditional")] = newTags.getShortRestrictionValue()!!
-                newTags.remove(oldConditionalKey)
-                currentRestriction = TurnRestriction(restriction.relation.copy(tags = newTags))
-            }
-            is WeightRestriction -> {
-                val newTags = restriction.way.tags.toMutableMap()
-                val weightKey = restriction.sign.osmKey
-                newTags.remove("$weightKey:conditional")
-                currentRestriction = WeightRestriction(restriction.way.copy(tags = newTags), restriction.sign, restriction.weight)
-            }
-        }
-    }
-
-    private fun onClickAddConditional() {
-        val restriction = currentRestriction ?: return
-        when (restriction) {
-            is TurnRestriction -> {
-                val newTags = restriction.relation.tags.toMutableMap()
-                // either it's only conditional, then value is same as restriction, or it's an exception then it's "none"
-                val restrictionKey = if (newTags.containsKey("restriction")) "restriction"
-                    else newTags.keys.firstOrNull { key -> onlyTurnRestriction.any { key =="restriction:$it" } } ?: "restriction"
-                val values = newTags[restrictionKey]?.let { listOf(it, "none") }
-                    ?: listOf(turnRestrictionTypeList[binding.turnRestrictionTypeSpinner.selectedItemPosition])
-                showAddConditionalDialog(requireContext(), listOf("$restrictionKey:conditional"), values, null) { _, v ->
-                    newTags["$restrictionKey:conditional"] = v
-                    if (!v.startsWith("none")) newTags.remove(restrictionKey)
-                    currentRestriction = TurnRestriction(restriction.relation.copy(tags = newTags))
-                }
-            }
-            is WeightRestriction -> {
-                val weightKey = restriction.sign.osmKey
-                val newTags = restriction.way.tags.toMutableMap()
-                // no values because it needs to be free-form (enter weight, maybe unit for some country, also none
-                // -> can't set number-only input type
-                showOtherConditionalDialog(requireContext(), listOf("$weightKey:conditional"), null, null) { _, v ->
-                    newTags["$weightKey:conditional"] = v
-                    if (!v.startsWith("none")) newTags.remove(weightKey)
-                    currentRestriction = WeightRestriction(restriction.way.copy(tags = newTags), restriction.sign, restriction.weight)
-                }
-            }
-        }
-    }
-
-    private fun onClickedDelete() {
-        val restriction = currentRestriction ?: return
-        when (restriction) {
-            is TurnRestriction -> {
-                if (restriction.relation.id == 0L) return
-                AlertDialog.Builder(requireContext())
-                    .setMessage(R.string.quest_generic_confirmation_title)
-                    .setPositiveButton(R.string.osm_element_gone_confirmation) { _, _ ->
-                        applyEdit(DeleteRelationAction(restriction.relation), getGeometry(restriction.relation) ?: geometry)
-                    }
-                    .setNeutralButton(R.string.leave_note) { _, _ -> composeNote(restriction.relation) }
-                    .show()
-            }
-            is WeightRestriction -> {
-                // delete this and conditional tags, but only apply if there are actually changes
-                val changes = restriction.way.tags.createChanges(element!!.tags)
-                changes.remove(restriction.sign.osmKey)
-                changes.keys.filter { it.startsWith("${restriction.sign.osmKey}:") }.forEach {
-                    changes.remove(it)
-                }
-                if (!changes.hasChanges) return
-
-                AlertDialog.Builder(requireContext())
-                    .setMessage(R.string.quest_generic_confirmation_title)
-                    .setPositiveButton(R.string.quest_generic_confirmation_yes) { _, _ ->
-                        applyEdit(UpdateElementTagsAction(restriction.way, changes.create()))
-                    }
-                    .setNeutralButton(R.string.leave_note) { _, _ -> composeNote(restriction.way) }
-                    .show()
-            }
-        }
-    }
-
-    // ---------------- weight restriction ----------------------
-
-    private fun showWeightRestrictionUi(restriction: WeightRestriction) {
-        binding.turnRestrictionContainer.isGone = true
-        binding.maxWeightContainer.isVisible = true
-        binding.maxWeightContainer.removeAllViews()
-        val item = restriction.sign.asItem(layoutInflater, countryInfo.countryCode)
-        layoutInflater.inflate(item.value!!.getLayoutResourceId(countryInfo.countryCode), binding.maxWeightContainer)
-        val units = countryInfo.weightLimitUnits
-        weightUnitSelect?.adapter = ArrayAdapter(requireContext(), R.layout.spinner_item_centered, units.map { it.displayString })
-        weightUnitSelect?.setSelection(0)
-        if (restriction.weight.toDoubleOrNull() == null) {
-            when {
-                restriction.weight.replace(',', '.').toDoubleOrNull() != null ->
-                    maxWeightInput?.setText(restriction.weight.replace(',', '.'))
-                restriction.weight.endsWith("lbs") -> {
-                    val w = restriction.weight.substringBefore("lbs").trim()
-                    if (w.toDoubleOrNull() != null) {
-                        maxWeightInput?.setText(w)
-                        val idx = units.indexOfFirst { it == WeightMeasurementUnit.POUND }
-                        if (idx != -1)
-                            weightUnitSelect?.setSelection(idx)
-                    }
-                }
-                restriction.weight.endsWith("st") -> {
-                    val w = restriction.weight.substringBefore("st").trim()
-                    if (w.toDoubleOrNull() != null) {
-                        maxWeightInput?.setText(w)
-                        val idx = units.indexOfFirst { it == WeightMeasurementUnit.SHORT_TON }
-                        if (idx != -1)
-                            weightUnitSelect?.setSelection(idx)
-                    }
-                }
-                restriction.weight.endsWith("t") -> {
-                    val w = restriction.weight.substringBefore("t").trim()
-                    if (w.toDoubleOrNull() != null)
-                        maxWeightInput?.setText(w)
-                }
-                else -> { } // don't fill unrecognized values
-            }
-        } else maxWeightInput?.setText(restriction.weight)
-        maxWeightInput?.filters = arrayOf(acceptDecimalDigits(6, 2))
-        binding.maxWeightContainer.setOnClickListener {
-            maxWeightInput?.requestFocus()
-            maxWeightInput?.showKeyboard()
-        }
-        maxWeightInput?.doAfterTextChanged {
-            currentRestriction = WeightRestriction(restriction.way, restriction.sign, it.toString())
-        }
-
-        // show other restrictions based on this maxweight key
-        val restrictionInfo = restriction.way.tags
-            .filterKeys { it.startsWith("${restriction.sign.osmKey}:") }
-            .map { "${it.key} = ${it.value}" }
-            .joinToString("\n")
-        displayConditionalRestrictions(restrictionInfo)
-
-        // todo: only-button for maxweight:hgv and stuff
-        //  but needs to work a bit different than for turn because of the maxweight keys
-    }
-
-    // ---------------- turn restriction ----------------------
-
-    private fun showFullTurnRestrictionUi(restriction: TurnRestriction) {
-        binding.turnRestrictionContainer.isVisible = true
-        binding.maxWeightContainer.isGone = true
-
-        // set up switch
-        binding.implicitSwitch.isChecked = restriction.relation.tags["implicit"] != "yes"
-        binding.implicitSwitch.setOnCheckedChangeListener { _, b ->
-            val oldRestriction = currentRestriction as? TurnRestriction ?: return@setOnCheckedChangeListener
-            val newTags = oldRestriction.relation.tags.toMutableMap()
-            if (b)
-                newTags.remove("implicit")
-            else newTags["implicit"] = "yes"
-            currentRestriction = TurnRestriction(oldRestriction.relation.copy(tags = newTags))
-        }
-
-        // set spinner value
-        val idx = turnRestrictionTypeList.indexOf(restriction.relation.tags.getShortRestrictionValue())
-        if (idx != binding.turnRestrictionTypeSpinner.selectedItemPosition) {
-            // if -1 selected (unknown restriction), view gets very small... not nice, but not worth the work
-            // without the post it doesn't work... though it used to work in a previous version of the form, wtf?
-            binding.turnRestrictionTypeSpinner.post { binding.turnRestrictionTypeSpinner.setSelection(idx) }
-        }
-
-        // todo: switching roles for an existing relation requires another new action...
-        //  maybe do that later, but currently this is only allowed when adding a new relation
-        binding.swapFromToRoles.setOnClickListener {
-            val rel = (currentRestriction as? TurnRestriction)?.relation ?: return@setOnClickListener
-            val newMembers = rel.members.map { when (it.role) {
-                "from" -> it.copy(role = "to")
-                "to" -> it.copy(role = "from")
-                else -> it
-            } }
-            currentRestriction = TurnRestriction(rel.copy(members = newMembers))
-        }
-        binding.exceptions.setOnClickListener { showTurnRestrictionExceptionsDialog() }
-
-        // set exceptions
-        val args = restriction.relation.tags["except"]?.replace(";", ", ") ?: getString(R.string.overlay_none)
-        binding.exceptions.text = getString(R.string.restriction_overlay_exceptions, args)
-
-        // show other restriction parts like conditional or unknown values
-        val restrictionInfo = restriction.relation.tags
-            .filterKeys { key -> key.startsWith("restriction:") && onlyTurnRestriction.none { key.endsWith(it) } }
-            .map { "${it.key} = ${it.value}" }
-            .joinToString("\n")
-        displayConditionalRestrictions(restrictionInfo)
-
-        // show only-restriction (restriction:hgv and similar)
-        binding.onlyButton.isVisible = true
-        val onlyFor = restriction.relation.tags.keys
-            .firstOrNull { it.startsWith("restriction") && it.substringAfter("restriction:").substringBefore(":conditional") in onlyTurnRestriction }
-        val onlyForText = onlyFor?.substringAfter("restriction:")?.substringBefore(":conditional") ?: "-"
-        binding.onlyButton.text = getString(R.string.restriction_overlay_only_for, onlyForText)
-        binding.onlyButton.setOnClickListener {
-            // move restriction and restriction:conditional
-            val d = AlertDialog.Builder(requireContext())
-                .setSingleChoiceItems(onlyTurnRestriction.toTypedArray(), onlyTurnRestriction.indexOf(onlyFor)) { d, i ->
-                    // using tags may not have been the best decision here... but whatever
-                    val newOnly = onlyTurnRestriction[i]
-                    val switchFrom = onlyFor?.let { ":$it" } ?: ""
-                    val newTags = restriction.relation.tags.toMutableMap()
-                    newTags.remove("restriction$switchFrom")?.let { newTags["restriction:$newOnly"] = it }
-                    newTags.remove("restriction$switchFrom:conditional")?.let { newTags["restriction:$newOnly:conditional"] = it }
-                    d.dismiss()
-                    currentRestriction = TurnRestriction(restriction.relation.copy(tags = newTags))
-                }
-                .setNegativeButton(android.R.string.cancel, null)
-            if (onlyFor != null)
-                d.setNeutralButton(R.string.delete_confirmation) { _, _ ->
-                    val newTags = restriction.relation.tags.toMutableMap()
-                    newTags.remove("restriction:$onlyFor")?.let { newTags["restriction"] = it }
-                    newTags.remove("restriction:$onlyFor:conditional")?.let { newTags["restriction:conditional"] = it }
-                    currentRestriction = TurnRestriction(restriction.relation.copy(tags = newTags))
-                }
-            d.show()
-        }
-    }
-
-    // get bearing of last segment of "from" member for via icon
-    private fun showTurnRestrictionOnMap(restriction: TurnRestriction) {
-        val members = restriction.relation.members.map { it.role to (mapDataSource.get(it.type, it.ref) ?: return) }
-        val viaMembers = members.filter { it.first == "via" }.map { it.second }
-        val from = members.singleOrNull { it.first == "from" }?.second as? Way ?: return // only one from member supported
-        val isFirst = viaMembers.any { it is Node && it.id == from.nodeIds.first() || it is Way && it.nodeIds.firstAndLast().contains(from.nodeIds.first()) }
-        val isLast = viaMembers.any { it is Node && it.id == from.nodeIds.last() || it is Way && it.nodeIds.firstAndLast().contains(from.nodeIds.last()) }
-        if (isFirst == isLast) return // should not happen
-        val nodeIdsForBearing = if (isFirst) from.nodeIds.take(2).reversed() else from.nodeIds.takeLast(2)
-        val nodesForBearing = nodeIdsForBearing.map { mapDataSource.getNode(it)!! }
-        val bearing = nodesForBearing.first().position.finalBearingTo(nodesForBearing.last().position)
-        via = nodesForBearing.last().position to bearing
-    }
-
-    private fun showUnsupportedTurnRestriction(restriction: TurnRestriction) {
-        val rel = restriction.relation
-        binding.turnRestrictionContainer.isVisible = true
-        binding.maxWeightContainer.isGone = true
-        binding.infoText.isVisible = true
-
-        if (rel.isRelationComplete()) {
-            binding.infoText.text = getString(R.string.restriction_overlay_relation_unsupported, rel.getDetailsText())
-        } else {
-            binding.infoText.setText(R.string.restriction_overlay_relation_incomplete)
-        }
-    }
-
-    private fun showTurnRestrictionExceptionsDialog() {
-        val restriction = currentRestriction as? TurnRestriction ?: return
-        val selectedExceptions = restriction.relation.tags["except"]?.split(";").orEmpty()
-        val selected = exceptions.map { it in selectedExceptions }
-        val newSelected = selected.toMutableList()
-        AlertDialog.Builder(requireContext())
-            .setMultiChoiceItems(exceptions.toTypedArray(), selected.toBooleanArray()) { _, i, s ->
-                newSelected[i] = s
-            }
-            .setNegativeButton(android.R.string.cancel, null)
-            .setPositiveButton(android.R.string.ok) { _, _ ->
-                if (selected == newSelected) return@setPositiveButton
-                val newTags = restriction.relation.tags.toMutableMap()
-                newTags["except"] = newSelected.zip(exceptions).mapNotNull { if (it.first) it.second else null }.joinToString(";")
-                currentRestriction = TurnRestriction(restriction.relation.copy(tags = newTags))
-            }
-            .show()
-    }
-
-    // ---------------- other answers ----------------------
-
-    private fun relationDetailsAnswer(): AnswerItem? {
-        val restriction = currentRestriction as? TurnRestriction ?: return null
-        return if (restriction.relation.id == 0L) null
-        else AnswerItem(R.string.restriction_overlay_show_details) {
-            AlertDialog.Builder(requireContext())
-                .setMessage(restriction.relation.getDetailsText())
-                .setPositiveButton(android.R.string.ok, null)
-                .setNeutralButton(R.string.quest_generic_answer_show_edit_tags) { _, _ ->
-                    editTags(restriction.relation, elementGeometry = getGeometry(restriction.relation), editTypeName = overlay.name)
-                }
-                .show()
-        }
-    }
-
-    // ---------------- relation stuff used for turn restriction ----------------------
-
-    private fun getGeometry(rel: Relation): ElementGeometry? {
-        if (rel.id != 0L)
-            return mapDataSource.getGeometry(rel.type, rel.id)
-        val ways = rel.members.mapNotNull { if (it.type == ElementType.WAY) it.key else null }
-        return ElementGeometryCreator().create(rel, mapDataSource.getGeometries(ways).associate { it.elementId to (it.geometry as ElementPolylinesGeometry).polylines.single() })
-    }
-
-    private fun Relation.isRelationComplete(): Boolean =
-        members.all { mapDataSource.get(it.type, it.ref) != null }
-
-    private fun Relation.getDetailsText(): String {
-        val tagsText = tags.entries.sortedBy { it.key }.joinToString("\n") { "${it.key} = ${it.value}" }
-        val membersText = members.joinToString("\n") { member ->
-            val element = mapDataSource.get(member.type, member.ref)!!
-            val memberDetails = getNameAndLocationSpanned(element, resources, featureDictionary, false)
-                ?.let { "${element.key}: $it" } ?: element.key.toString()
-            "${member.role}: $memberDetails"
-        }
-        return "$tagsText\n\n$membersText"
-    }
-}
-
-// accessing restrictionTypes by index is absurdly complicated... the set is ordered, so wtf?
-private val turnRestrictionTypeList = turnRestrictionTypes.toList()
-
-// most used according to taginfo
-private val exceptions = listOf(
-    "bicycle", "psv", "bus", "emergency", "agricultural", "hgv", "moped", "destination", "motorcar"
-)
-*/
-// restriction:* list from wiki
-private val onlyTurnRestriction = listOf(
-    "hgv", "caravan", "motorcar", "bus", "agricultural", "motorcycle", "bicycle", "hazmat"
-)
-
-val onlyTurnRestrictionSet = onlyTurnRestriction.toHashSet()
-
-// actually this may be country specific!
-private fun getIconForTurnRestriction(type: String?) = when(type) {
-    "no_right_turn" -> Res.drawable.ic_restriction_no_right_turn
-    "no_left_turn" -> Res.drawable.ic_restriction_no_left_turn
-    "no_u_turn" -> Res.drawable.ic_restriction_no_u_turn
-    "no_straight_on" -> Res.drawable.ic_restriction_no_straight_on
-    "only_right_turn" -> Res.drawable.ic_restriction_only_right_turn
-    "only_left_turn" -> Res.drawable.ic_restriction_only_left_turn
-    "only_straight_on" -> Res.drawable.ic_restriction_only_straight_on
-    else -> Res.drawable.ic_restriction_unknown // currently the note icon, but half size
-}
-
-fun Map<String, String>.getShortRestrictionValue(): String? {
-    get("restriction")?.let { return it }
-    get("restriction:conditional")?.let { return it.substringBefore("@").trim() }
-    entries.firstOrNull { it.key.startsWith("restriction:") }?.let { return it.value.substringBefore("@").trim() } // restriction:hgv and similar, may be conditional
-    return null
-}
-/*
-// todo: switch form changing tags to sth else, this is getting way too complicated to handle
-private sealed interface Restriction {
-    val type: RestrictionType
-    val element: Element
-    fun getDrawable(inflater: LayoutInflater, countryInfo: CountryInfo): Drawable?
-}
-
-private data class TurnRestriction(val relation: Relation) : Restriction {
-    override val type = RestrictionType.TURN
-    override val element get () = relation
-    override fun getDrawable(inflater: LayoutInflater, countryInfo: CountryInfo) =
-        ContextCompat.getDrawable(inflater.context, getIconForTurnRestriction(relation.tags.getShortRestrictionValue()))
-}
-
-private data class WeightRestriction(val way: Way, val sign: MaxWeightSign, val weight: String) : Restriction {
-    override val type = RestrictionType.WEIGHT
-    override val element get () = way
-    override fun getDrawable(inflater: LayoutInflater, countryInfo: CountryInfo) =
-        (sign.asItem(inflater, countryInfo.countryCode).image as? DrawableImage)?.drawable
-}
+import de.westnordost.streetcomplete.resources.access_manager_button_add_conditional
+import de.westnordost.streetcomplete.resources.add
+import de.westnordost.streetcomplete.resources.cancel
+import de.westnordost.streetcomplete.resources.delete_confirmation
+import de.westnordost.streetcomplete.resources.ic_overlay_restriction
+import de.westnordost.streetcomplete.resources.leave_note
+import de.westnordost.streetcomplete.resources.ok
+import de.westnordost.streetcomplete.resources.osm_element_gone_confirmation
+import de.westnordost.streetcomplete.resources.overlay_none
+import de.westnordost.streetcomplete.resources.quest_generic_confirmation_title
+import de.westnordost.streetcomplete.resources.quest_generic_confirmation_yes
+import de.westnordost.streetcomplete.resources.quest_max_weight
+import de.westnordost.streetcomplete.resources.restriction_overlay_exceptions
+import de.westnordost.streetcomplete.resources.restriction_overlay_only_for
+import de.westnordost.streetcomplete.resources.restriction_overlay_other_restrictions
+import de.westnordost.streetcomplete.resources.restriction_overlay_relation_incomplete
+import de.westnordost.streetcomplete.resources.restriction_overlay_relation_unsupported
+import de.westnordost.streetcomplete.resources.restriction_overlay_remove_conditional_restrictions
+import de.westnordost.streetcomplete.resources.restriction_overlay_select_way
+import de.westnordost.streetcomplete.resources.restriction_overlay_show_details
+import de.westnordost.streetcomplete.resources.restriction_overlay_signed_switch
+import de.westnordost.streetcomplete.ui.common.Button2
+import de.westnordost.streetcomplete.ui.common.ButtonStyle
+import de.westnordost.streetcomplete.ui.common.DropdownButton
+import de.westnordost.streetcomplete.ui.common.dialogs.AlertDialog
+import de.westnordost.streetcomplete.ui.common.dialogs.InfoDialog
+import de.westnordost.streetcomplete.ui.common.dialogs.ScrollableAlertDialog
+import de.westnordost.streetcomplete.ui.common.dialogs.SimpleItemSelectDialog
+import de.westnordost.streetcomplete.ui.common.item_select.ImageWithLabel
+import de.westnordost.streetcomplete.ui.common.overlay.OverlayForm
+import de.westnordost.streetcomplete.ui.common.quest.AnswerItem
+import de.westnordost.streetcomplete.ui.common.quest.LocalLastMapClick
+import de.westnordost.streetcomplete.ui.common.quest.LocalMapMarkersCallback
+import de.westnordost.streetcomplete.ui.common.quest.LocalSetOverlayVisibleCallback
+import de.westnordost.streetcomplete.ui.common.quest.Marker
+import de.westnordost.streetcomplete.ui.util.rememberSerializable
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
 private enum class RestrictionType { TURN, WEIGHT }
 
-private fun getWeightRestrictions(way: Way): List<WeightRestriction> {
-    val restrictions = mutableListOf<WeightRestriction>()
-    for (sign in MaxWeightSign.entries) {
-        val key = if (way.tags.containsKey(sign.osmKey)) sign.osmKey
-            else way.tags.keys.firstOrNull { it == "${sign.osmKey}:conditional" } ?: continue
-        val weight = way.tags[key]!!
-        restrictions.add(WeightRestriction(way, sign, weight))
+@Composable
+fun RestrictionOverlayWayForm(
+    on: (OverlayAction) -> Unit,
+    element: Element, // Way
+    geometry: ElementGeometry,
+    countryInfo: CountryInfo,
+    mapDataWithEditsSource: MapDataWithEditsSource = koinInject(),
+) {
+    // Selected way geometry; used as map highlight fallback when no relation geometry exists.
+    val wayGeometry = geometry
+    val way = element as Way
+    val locale = countryInfo.languageTag?.let { Locale(it) } ?: Locale.current
+    val units = countryInfo.weightLimitUnits
+
+    val originalRestrictions = remember(way.id) {
+        getOriginalRestrictions(way, mapDataWithEditsSource)
     }
-    return restrictions
+
+    var selectedRestriction by rememberSerializable {
+        mutableStateOf(
+            getInitialRestrictionPreferComplete(originalRestrictions) {
+                isRelationComplete(it, mapDataWithEditsSource)
+            }
+        )
+    }
+    var currentRestriction by rememberSerializable {
+        mutableStateOf(selectedRestriction)
+    }
+
+    var turnRestrictionSelectionMode by rememberSaveable { mutableStateOf(false) }
+    var canSwapFromTo by rememberSaveable { mutableStateOf(false) }
+    var draftSigned by rememberSaveable {
+        mutableStateOf(
+            (selectedRestriction as? TurnRestriction)?.relation?.tags?.get("implicit") != "yes"
+        )
+    }
+    var draftTurnType by rememberSaveable {
+        mutableStateOf(
+            (selectedRestriction as? TurnRestriction)?.relation?.tags?.getShortRestrictionValue()
+                ?.takeIf { it in turnRestrictionTypeList }
+                ?: turnRestrictionTypeList.first()
+        )
+    }
+
+    // Weight input including unit (weight string on WeightRestriction stays numeric for isComplete)
+    var editedWeight by rememberSerializable {
+        mutableStateOf(
+            (selectedRestriction as? WeightRestriction)?.let { parseWeight(it.weight, units) }
+        )
+    }
+
+    var showAddRestrictionDialog by remember { mutableStateOf(false) }
+    var showWeightTypeDialog by remember { mutableStateOf(false) }
+    var showExceptionsDialog by remember { mutableStateOf(false) }
+    var showOnlyForDialog by remember { mutableStateOf(false) }
+    var showAddConditionalDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    var showRelationDetails by remember { mutableStateOf(false) }
+
+    val setOverlayVisible = LocalSetOverlayVisibleCallback.current
+    val mapClick = LocalLastMapClick.current
+    val mapMarkersCallback = LocalMapMarkersCallback.current
+
+    val hasChanges = currentRestriction != null && currentRestriction != selectedRestriction
+    val isComplete = when (val restriction = currentRestriction) {
+        is WeightRestriction -> hasChanges && editedWeight != null
+        is TurnRestriction -> hasChanges
+        null -> false
+    }
+
+    val showAddButton =
+        !turnRestrictionSelectionMode && currentRestriction == selectedRestriction
+
+    fun selectRestriction(restriction: RestrictionOverlayRestriction) {
+        selectedRestriction = restriction
+        currentRestriction = restriction
+        canSwapFromTo = false
+        turnRestrictionSelectionMode = false
+        if (restriction is WeightRestriction) {
+            editedWeight = parseWeight(restriction.weight, units)
+        } else {
+            editedWeight = null
+        }
+        if (restriction is TurnRestriction) {
+            restriction.relation.tags.getShortRestrictionValue()
+                ?.takeIf { it in turnRestrictionTypeList }
+                ?.let { draftTurnType = it }
+            draftSigned = restriction.relation.tags["implicit"] != "yes"
+        }
+    }
+
+    LaunchedEffect(turnRestrictionSelectionMode) {
+        setOverlayVisible?.invoke(!turnRestrictionSelectionMode)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            setOverlayVisible?.invoke(true)
+            mapMarkersCallback?.invoke(emptyList())
+        }
+    }
+
+    LaunchedEffect(mapClick?.timestamp) {
+        val click = mapClick ?: return@LaunchedEffect
+        if (!turnRestrictionSelectionMode) return@LaunchedEffect
+        val (toWay, viaNode) = findEligibleToWay(
+            position = click.position,
+            clickAreaSizeInMeters = click.clickAreaSizeInMeters,
+            fromWay = way,
+            mapDataSource = mapDataWithEditsSource,
+        ) ?: return@LaunchedEffect
+
+        val baseTags = (currentRestriction as? TurnRestriction)?.relation?.tags.orEmpty()
+        val relation = createTurnRestrictionRelation(
+            fromWay = way,
+            toWay = toWay,
+            viaNode = viaNode,
+            restrictionType = draftTurnType,
+            signed = draftSigned,
+            baseTags = baseTags,
+        )
+        currentRestriction = TurnRestriction(relation)
+        canSwapFromTo = true
+        turnRestrictionSelectionMode = false
+    }
+
+    LaunchedEffect(currentRestriction, draftTurnType, wayGeometry, turnRestrictionSelectionMode) {
+        if (turnRestrictionSelectionMode) {
+            mapMarkersCallback?.invoke(listOf(Marker(wayGeometry)))
+            return@LaunchedEffect
+        }
+        when (val restriction = currentRestriction) {
+            is TurnRestriction -> {
+                val markers = mutableListOf<Marker>()
+                (relationGeometry(restriction.relation, mapDataWithEditsSource) ?: wayGeometry)
+                    .let { markers += Marker(it) }
+                viaBearingForTurnRestriction(restriction.relation, mapDataWithEditsSource)
+                    ?.let { (position, bearing) ->
+                        val type = restriction.relation.tags.getShortRestrictionValue() ?: draftTurnType
+                        markers += Marker(
+                            geometry = pointGeometry(position),
+                            icon = getIconForTurnRestriction(type),
+                            rotation = bearing,
+                        )
+                    }
+                mapMarkersCallback?.invoke(markers)
+            }
+            is WeightRestriction -> mapMarkersCallback?.invoke(listOf(Marker(wayGeometry)))
+            null -> mapMarkersCallback?.invoke(emptyList())
+        }
+    }
+
+    OverlayForm(
+        on = on,
+        isComplete = isComplete,
+        hasChanges = hasChanges,
+        onClickOk = {
+            when (val restriction = currentRestriction) {
+                is WeightRestriction -> {
+                    val weight = editedWeight
+                        ?: parseWeight(restriction.weight, units)
+                        ?: return@OverlayForm
+                    val changes = restriction.way.tags.createChanges(way.tags)
+                    changes[restriction.type.osmKey] = weight.toOsmString()
+                    on(Edit(UpdateElementTagsAction(restriction.way, changes.create())))
+                }
+                is TurnRestriction -> {
+                    val rel = restriction.relation
+                    if (rel.id == 0L) {
+                        on(Edit(CreateRelationAction(rel.tags, rel.members)))
+                    } else {
+                        val oldRelation = (selectedRestriction as? TurnRestriction)?.relation
+                            ?: return@OverlayForm
+                        on(
+                            Edit(
+                                UpdateElementTagsAction(
+                                    oldRelation,
+                                    rel.tags.createChanges(oldRelation.tags).create()
+                                )
+                            )
+                        )
+                    }
+                }
+                null -> Unit
+            }
+        },
+        otherAnswers = {
+            listOfNotNull(
+                (currentRestriction as? TurnRestriction)
+                    ?.takeIf { it.relation.id != 0L }
+                    ?.let {
+                        AnswerItem(stringResource(Res.string.restriction_overlay_show_details)) {
+                            showRelationDetails = true
+                        }
+                    }
+            )
+        },
+    ) {
+        // BottomSheetFormScaffold (via OverlayForm) already owns verticalScroll;
+        // nested verticalScroll here receives infinite max height and crashes.
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OtherRestrictionsList(
+                originalRestrictions = originalRestrictions,
+                selectedRestriction = selectedRestriction,
+                wayId = way.id,
+                countryCode = countryInfo.countryCode.orEmpty(),
+                onSelect = ::selectRestriction,
+            )
+
+            when {
+                turnRestrictionSelectionMode -> {
+                    TurnRestrictionEditor(
+                        relation = (currentRestriction as? TurnRestriction)?.relation,
+                        draftTurnType = draftTurnType,
+                        draftSigned = draftSigned,
+                        canSwapFromTo = false,
+                        selectionMode = true,
+                        onTurnTypeChange = { draftTurnType = it },
+                        onSignedChange = { draftSigned = it },
+                        onSwap = {},
+                        onExceptionsClick = {},
+                        onOnlyForClick = {},
+                        onConditionalClick = {},
+                        conditionalLabel = stringResource(Res.string.access_manager_button_add_conditional),
+                        infoText = stringResource(Res.string.restriction_overlay_select_way),
+                        showOnlyFor = false,
+                    )
+                }
+                currentRestriction is TurnRestriction -> {
+                    val turn = currentRestriction as TurnRestriction
+                    if (turn.relation.isSupportedTurnRestriction()) {
+                        val infoText = turn.relation.tags
+                            .filterKeys { key ->
+                                key.startsWith("restriction:") &&
+                                    onlyTurnRestriction.none { key.endsWith(it) }
+                            }
+                            .map { "${it.key} = ${it.value}" }
+                            .joinToString("\n")
+                        TurnRestrictionEditor(
+                            relation = turn.relation,
+                            draftTurnType = draftTurnType,
+                            draftSigned = draftSigned,
+                            canSwapFromTo = canSwapFromTo || turn.relation.id == 0L,
+                            selectionMode = false,
+                            onTurnTypeChange = { type ->
+                                draftTurnType = type
+                                currentRestriction = TurnRestriction(
+                                    withTurnRestrictionType(turn.relation, type)
+                                )
+                            },
+                            onSignedChange = { signed ->
+                                draftSigned = signed
+                                currentRestriction = TurnRestriction(
+                                    withImplicitSigned(turn.relation, signed)
+                                )
+                            },
+                            onSwap = {
+                                currentRestriction = TurnRestriction(
+                                    withSwappedFromTo(turn.relation)
+                                )
+                            },
+                            onExceptionsClick = { showExceptionsDialog = true },
+                            onOnlyForClick = { showOnlyForDialog = true },
+                            onConditionalClick = {
+                                if (infoText.isNotBlank()) {
+                                    currentRestriction = removeConditional(turn)
+                                } else {
+                                    showAddConditionalDialog = true
+                                }
+                            },
+                            conditionalLabel = if (infoText.isNotBlank()) {
+                                stringResource(Res.string.restriction_overlay_remove_conditional_restrictions)
+                            } else {
+                                stringResource(Res.string.access_manager_button_add_conditional)
+                            },
+                            infoText = infoText.ifBlank { null },
+                            showOnlyFor = true,
+                        )
+                    } else {
+                        UnsupportedTurnRestrictionInfo(
+                            relation = turn.relation,
+                            mapDataWithEditsSource = mapDataWithEditsSource,
+                        )
+                    }
+                }
+                currentRestriction is WeightRestriction -> {
+                    val weightRestriction = currentRestriction as WeightRestriction
+                    val restrictionInfo = weightRestriction.way.tags
+                        .filterKeys { it.startsWith("${weightRestriction.type.osmKey}:") }
+                        .map { "${it.key} = ${it.value}" }
+                        .joinToString("\n")
+
+                    MaxWeightSignForm(
+                        type = weightRestriction.type,
+                        weight = editedWeight,
+                        onWeightChange = { newWeight ->
+                            editedWeight = newWeight
+                            currentRestriction = WeightRestriction(
+                                way = weightRestriction.way,
+                                type = weightRestriction.type,
+                                weight = newWeight?.toOsmString().orEmpty(),
+                            )
+                        },
+                        locale = locale,
+                        selectableUnits = units,
+                    )
+
+                    Button2(
+                        onClick = {
+                            if (restrictionInfo.isNotBlank()) {
+                                currentRestriction = removeConditional(weightRestriction)
+                            } else {
+                                showAddConditionalDialog = true
+                            }
+                        },
+                        style = ButtonStyle.Text,
+                    ) {
+                        Text(
+                            if (restrictionInfo.isNotBlank()) {
+                                stringResource(Res.string.restriction_overlay_remove_conditional_restrictions)
+                            } else {
+                                stringResource(Res.string.access_manager_button_add_conditional)
+                            }
+                        )
+                    }
+                    if (restrictionInfo.isNotBlank()) {
+                        Text(restrictionInfo, style = MaterialTheme.typography.body2)
+                    }
+                }
+            }
+
+            if (showAddButton) {
+                Button2(onClick = { showAddRestrictionDialog = true }) {
+                    Text(stringResource(Res.string.add))
+                }
+            }
+
+            val showRemove = when (val restriction = currentRestriction) {
+                is TurnRestriction -> restriction.relation.id != 0L
+                is WeightRestriction -> true
+                null -> false
+            }
+            if (showRemove && !turnRestrictionSelectionMode) {
+                Button2(
+                    onClick = { showDeleteDialog = true },
+                    style = ButtonStyle.Outlined,
+                ) {
+                    Text(stringResource(Res.string.delete_confirmation))
+                }
+            }
+        }
+    }
+
+    if (showAddRestrictionDialog) {
+        SimpleItemSelectDialog(
+            onDismissRequest = { showAddRestrictionDialog = false },
+            columns = SimpleGridCells.Fixed(2),
+            items = RestrictionType.entries,
+            onSelected = { type ->
+                when (type) {
+                    RestrictionType.TURN -> {
+                        turnRestrictionSelectionMode = true
+                        draftSigned = true
+                        draftTurnType = turnRestrictionTypeList.first()
+                        canSwapFromTo = false
+                    }
+                    RestrictionType.WEIGHT -> showWeightTypeDialog = true
+                }
+            },
+            itemContent = { type ->
+                val icon = when (type) {
+                    RestrictionType.TURN -> Res.drawable.ic_overlay_restriction
+                    RestrictionType.WEIGHT -> Res.drawable.quest_max_weight
+                }
+                Image(painterResource(icon), contentDescription = type.name)
+            },
+        )
+    }
+
+    if (showWeightTypeDialog) {
+        val availableTypes = MaxWeightType.entries.filter { type ->
+            originalRestrictions.none { it is WeightRestriction && it.type == type } &&
+                type.getIcon(countryInfo.countryCode.orEmpty()) != null
+        }
+        SimpleItemSelectDialog(
+            onDismissRequest = { showWeightTypeDialog = false },
+            columns = SimpleGridCells.Fixed(2),
+            items = availableTypes,
+            onSelected = { type ->
+                editedWeight = null
+                currentRestriction = WeightRestriction(way, type, "")
+            },
+            itemContent = { type ->
+                val icon = type.getIcon(countryInfo.countryCode.orEmpty())
+                if (icon != null) Image(painterResource(icon), contentDescription = type.name)
+            },
+        )
+    }
+
+    if (showExceptionsDialog) {
+        val turn = currentRestriction as? TurnRestriction
+        if (turn != null) {
+            ExceptionsMultiChoiceDialog(
+                selected = turn.relation.tags["except"]
+                    ?.split(";")
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotEmpty() }
+                    .orEmpty()
+                    .toSet(),
+                onDismissRequest = { showExceptionsDialog = false },
+                onConfirm = { exceptions ->
+                    currentRestriction = TurnRestriction(
+                        withExceptions(
+                            turn.relation,
+                            turnRestrictionExceptions.filter { it in exceptions }
+                        )
+                    )
+                    showExceptionsDialog = false
+                },
+            )
+        } else {
+            showExceptionsDialog = false
+        }
+    }
+
+    if (showOnlyForDialog) {
+        val turn = currentRestriction as? TurnRestriction
+        if (turn != null) {
+            OnlyForDialog(
+                currentOnly = currentOnlyFor(turn.relation),
+                onDismissRequest = { showOnlyForDialog = false },
+                onSelected = { onlyFor ->
+                    currentRestriction = TurnRestriction(withOnlyFor(turn.relation, onlyFor))
+                    showOnlyForDialog = false
+                },
+                onClear = {
+                    currentRestriction = TurnRestriction(withOnlyFor(turn.relation, null))
+                    showOnlyForDialog = false
+                },
+            )
+        } else {
+            showOnlyForDialog = false
+        }
+    }
+
+    if (showAddConditionalDialog) {
+        when (val restriction = currentRestriction) {
+            is TurnRestriction -> {
+                val tags = restriction.relation.tags
+                val restrictionKey = when {
+                    tags.containsKey("restriction") -> "restriction"
+                    else -> tags.keys.firstOrNull { key ->
+                        onlyTurnRestriction.any { key == "restriction:$it" }
+                    } ?: "restriction"
+                }
+                val values = tags[restrictionKey]?.let { listOf(it, "none") }
+                    ?: listOf(draftTurnType)
+                AddConditionalDialog(
+                    onDismissRequest = { showAddConditionalDialog = false },
+                    keys = listOf("$restrictionKey:conditional"),
+                    values = values,
+                    numberOnly = false,
+                    countryInfo = countryInfo,
+                ) { key, value ->
+                    val newTags = tags.toMutableMap()
+                    newTags[key] = value
+                    if (!value.startsWith("none")) newTags.remove(restrictionKey)
+                    currentRestriction = TurnRestriction(restriction.relation.copy(tags = newTags))
+                    showAddConditionalDialog = false
+                }
+            }
+            is WeightRestriction -> {
+                val weightKey = restriction.type.osmKey
+                AddConditionalDialog(
+                    onDismissRequest = { showAddConditionalDialog = false },
+                    keys = listOf("$weightKey:conditional"),
+                    values = null,
+                    numberOnly = false,
+                    countryInfo = countryInfo,
+                ) { key, value ->
+                    val newTags = restriction.way.tags.toMutableMap()
+                    newTags[key] = value
+                    if (!value.startsWith("none")) newTags.remove(weightKey)
+                    currentRestriction = WeightRestriction(
+                        way = restriction.way.copy(tags = newTags),
+                        type = restriction.type,
+                        weight = restriction.weight,
+                    )
+                    showAddConditionalDialog = false
+                }
+            }
+            null -> showAddConditionalDialog = false
+        }
+    }
+
+    if (showDeleteDialog) {
+        when (val restriction = currentRestriction) {
+            is TurnRestriction -> {
+                if (restriction.relation.id == 0L) {
+                    showDeleteDialog = false
+                } else {
+                    AlertDialog(
+                        onDismissRequest = { showDeleteDialog = false },
+                        text = { Text(stringResource(Res.string.quest_generic_confirmation_title)) },
+                        buttonRow = {
+                            TextButton(onClick = { showDeleteDialog = false }) {
+                                Text(stringResource(Res.string.cancel))
+                            }
+                            TextButton(onClick = {
+                                showDeleteDialog = false
+                                on(Action.LeaveNote)
+                            }) {
+                                Text(stringResource(Res.string.leave_note))
+                            }
+                            TextButton(onClick = {
+                                showDeleteDialog = false
+                                on(Edit(DeleteRelationAction(restriction.relation)))
+                            }) {
+                                Text(stringResource(Res.string.osm_element_gone_confirmation))
+                            }
+                        },
+                    )
+                }
+            }
+            is WeightRestriction -> {
+                AlertDialog(
+                    onDismissRequest = { showDeleteDialog = false },
+                    text = { Text(stringResource(Res.string.quest_generic_confirmation_title)) },
+                    buttonRow = {
+                        TextButton(onClick = { showDeleteDialog = false }) {
+                            Text(stringResource(Res.string.cancel))
+                        }
+                        TextButton(onClick = {
+                            showDeleteDialog = false
+                            on(Action.LeaveNote)
+                        }) {
+                            Text(stringResource(Res.string.leave_note))
+                        }
+                        TextButton(onClick = {
+                            val changes = restriction.way.tags.createChanges(way.tags)
+                            changes.remove(restriction.type.osmKey)
+                            changes.keys
+                                .filter { it.startsWith("${restriction.type.osmKey}:") }
+                                .toList()
+                                .forEach { changes.remove(it) }
+                            showDeleteDialog = false
+                            if (changes.hasChanges) {
+                                on(Edit(UpdateElementTagsAction(restriction.way, changes.create())))
+                            }
+                        }) {
+                            Text(stringResource(Res.string.quest_generic_confirmation_yes))
+                        }
+                    },
+                )
+            }
+            null -> showDeleteDialog = false
+        }
+    }
+
+    if (showRelationDetails) {
+        val turn = currentRestriction as? TurnRestriction
+        if (turn != null && turn.relation.id != 0L) {
+            InfoDialog(
+                onDismissRequest = { showRelationDetails = false },
+                title = { Text(stringResource(Res.string.restriction_overlay_show_details)) },
+                text = {
+                    Text(relationDetailsText(turn.relation, mapDataWithEditsSource))
+                },
+            )
+        } else {
+            showRelationDetails = false
+        }
+    }
 }
-*/
+
+@Composable
+private fun OtherRestrictionsList(
+    originalRestrictions: List<RestrictionOverlayRestriction>,
+    selectedRestriction: RestrictionOverlayRestriction?,
+    wayId: Long,
+    countryCode: String,
+    onSelect: (RestrictionOverlayRestriction) -> Unit,
+) {
+    val others = originalRestrictions.filterNot { it == selectedRestriction }
+    if (others.isEmpty()) return
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(stringResource(Res.string.restriction_overlay_other_restrictions))
+        for (restriction in others) {
+            val label = when (restriction) {
+                is TurnRestriction -> restriction.relation.members
+                    .filter { it.type == ElementType.WAY && it.ref == wayId }
+                    .joinToString(", ") { it.role }
+                is WeightRestriction -> restriction.weight
+            }
+            val icon = when (restriction) {
+                is TurnRestriction ->
+                    getIconForTurnRestriction(restriction.relation.tags.getShortRestrictionValue())
+                is WeightRestriction ->
+                    restriction.type.getIcon(countryCode) ?: Res.drawable.quest_max_weight
+            }
+            Button2(onClick = { onSelect(restriction) }, style = ButtonStyle.Outlined) {
+                ImageWithLabel(
+                    painter = painterResource(icon),
+                    label = label,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TurnRestrictionEditor(
+    relation: Relation?,
+    draftTurnType: String,
+    draftSigned: Boolean,
+    canSwapFromTo: Boolean,
+    selectionMode: Boolean,
+    onTurnTypeChange: (String) -> Unit,
+    onSignedChange: (Boolean) -> Unit,
+    onSwap: () -> Unit,
+    onExceptionsClick: () -> Unit,
+    onOnlyForClick: () -> Unit,
+    onConditionalClick: () -> Unit,
+    conditionalLabel: String,
+    infoText: String?,
+    showOnlyFor: Boolean,
+) {
+    val selectedType = relation?.tags?.getShortRestrictionValue()
+        ?.takeIf { it in turnRestrictionTypeList }
+        ?: draftTurnType
+
+    DropdownButton(
+        items = turnRestrictionTypeList,
+        selectedItem = selectedType,
+        onSelectedItem = onTurnTypeChange,
+        itemContent = { type ->
+            ImageWithLabel(
+                painter = painterResource(getIconForTurnRestriction(type)),
+                label = type,
+            )
+        },
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = draftSigned,
+                onValueChange = onSignedChange,
+                role = Role.Switch,
+            )
+            .padding(horizontal = 8.dp),
+    ) {
+        Text(
+            text = stringResource(Res.string.restriction_overlay_signed_switch),
+            modifier = Modifier.weight(1f),
+        )
+        Switch(checked = draftSigned, onCheckedChange = onSignedChange)
+    }
+
+    if (!selectionMode && relation != null) {
+        val exceptionsArgs = relation.tags["except"]?.replace(";", ", ")
+            ?: stringResource(Res.string.overlay_none)
+        Button2(onClick = onExceptionsClick, style = ButtonStyle.Outlined) {
+            Text(stringResource(Res.string.restriction_overlay_exceptions, exceptionsArgs))
+        }
+
+        if (showOnlyFor) {
+            val onlyForText = currentOnlyFor(relation) ?: "-"
+            Button2(onClick = onOnlyForClick, style = ButtonStyle.Outlined) {
+                Text(stringResource(Res.string.restriction_overlay_only_for, onlyForText))
+            }
+        }
+
+        if (canSwapFromTo && relation.id == 0L) {
+            Button2(onClick = onSwap, style = ButtonStyle.Outlined) {
+                Text("from ↔ to")
+            }
+        }
+
+        Button2(onClick = onConditionalClick, style = ButtonStyle.Text) {
+            Text(conditionalLabel)
+        }
+    }
+
+    if (!infoText.isNullOrBlank()) {
+        Text(
+            text = infoText,
+            style = MaterialTheme.typography.body2,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+    }
+}
+
+@Composable
+private fun UnsupportedTurnRestrictionInfo(
+    relation: Relation,
+    mapDataWithEditsSource: MapDataWithEditsSource,
+) {
+    val text = if (isRelationComplete(relation, mapDataWithEditsSource)) {
+        stringResource(
+            Res.string.restriction_overlay_relation_unsupported,
+            relationDetailsText(relation, mapDataWithEditsSource),
+        )
+    } else {
+        stringResource(Res.string.restriction_overlay_relation_incomplete)
+    }
+    Text(text)
+}
+
+@Composable
+private fun ExceptionsMultiChoiceDialog(
+    selected: Set<String>,
+    onDismissRequest: () -> Unit,
+    onConfirm: (Set<String>) -> Unit,
+) {
+    val selectedStates = remember(selected) {
+        mutableStateMapOf<String, Boolean>().apply {
+            turnRestrictionExceptions.forEach { put(it, it in selected) }
+        }
+    }
+
+    ScrollableAlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = {
+            Text(
+                text = stringResource(Res.string.restriction_overlay_exceptions, ""),
+                style = MaterialTheme.typography.subtitle1,
+                fontWeight = FontWeight.SemiBold,
+            )
+        },
+        content = {
+            Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)) {
+                turnRestrictionExceptions.forEach { value ->
+                    val checked = selectedStates[value] == true
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .toggleable(
+                                value = checked,
+                                onValueChange = { selectedStates[value] = it },
+                            ),
+                    ) {
+                        Checkbox(
+                            checked = checked,
+                            onCheckedChange = { selectedStates[value] = it },
+                        )
+                        Text(value, modifier = Modifier.padding(start = 6.dp))
+                    }
+                }
+            }
+        },
+        buttonRow = {
+            TextButton(onClick = onDismissRequest) {
+                Text(stringResource(Res.string.cancel))
+            }
+            TextButton(
+                onClick = { onConfirm(selectedStates.filterValues { it }.keys) }
+            ) {
+                Text(stringResource(Res.string.ok))
+            }
+        },
+    )
+}
+
+@Composable
+private fun OnlyForDialog(
+    currentOnly: String?,
+    onDismissRequest: () -> Unit,
+    onSelected: (String) -> Unit,
+    onClear: () -> Unit,
+) {
+    var selected by remember(currentOnly) { mutableStateOf(currentOnly) }
+
+    ScrollableAlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = {
+            Text(
+                text = stringResource(Res.string.restriction_overlay_only_for, currentOnly ?: "-"),
+                style = MaterialTheme.typography.subtitle1,
+                fontWeight = FontWeight.SemiBold,
+            )
+        },
+        content = {
+            Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)) {
+                onlyTurnRestriction.forEach { value ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .toggleable(
+                                value = selected == value,
+                                onValueChange = {
+                                    selected = value
+                                    onSelected(value)
+                                },
+                            ),
+                    ) {
+                        RadioButton(
+                            selected = selected == value,
+                            onClick = {
+                                selected = value
+                                onSelected(value)
+                            },
+                        )
+                        Text(value, modifier = Modifier.padding(start = 6.dp))
+                    }
+                }
+            }
+        },
+        buttonRow = {
+            TextButton(onClick = onDismissRequest) {
+                Text(stringResource(Res.string.cancel))
+            }
+            if (currentOnly != null) {
+                TextButton(onClick = onClear) {
+                    Text(stringResource(Res.string.delete_confirmation))
+                }
+            }
+        },
+    )
+}
+
+private fun removeConditional(
+    restriction: RestrictionOverlayRestriction,
+): RestrictionOverlayRestriction = when (restriction) {
+    is TurnRestriction -> {
+        val newTags = restriction.relation.tags.toMutableMap()
+        val oldConditionalKey = when {
+            newTags.containsKey("restriction:conditional") -> "restriction:conditional"
+            else -> newTags.keys.firstOrNull {
+                it.startsWith("restriction:") && it.endsWith(":conditional")
+            } ?: "restriction:conditional"
+        }
+        val baseKey = oldConditionalKey.substringBefore(":conditional")
+        if (!newTags.containsKey(baseKey)) {
+            newTags.getShortRestrictionValue()?.let { newTags[baseKey] = it }
+        }
+        newTags.remove(oldConditionalKey)
+        TurnRestriction(restriction.relation.copy(tags = newTags))
+    }
+    is WeightRestriction -> {
+        val newTags = restriction.way.tags.toMutableMap()
+        newTags.remove("${restriction.type.osmKey}:conditional")
+        WeightRestriction(
+            way = restriction.way.copy(tags = newTags),
+            type = restriction.type,
+            weight = restriction.weight,
+        )
+    }
+}
+
+private fun parseWeight(
+    weightString: String,
+    units: List<WeightMeasurementUnit>,
+): Weight? {
+    if (weightString.isBlank()) return null
+    val normalized = weightString.replace(',', '.')
+    normalized.toDoubleOrNull()?.let {
+        return Weight(it, units.firstOrNull() ?: WeightMeasurementUnit.METRIC_TON)
+    }
+    when {
+        weightString.endsWith("lbs") -> {
+            val w = weightString.substringBefore("lbs").trim().replace(',', '.').toDoubleOrNull()
+                ?: return null
+            val unit = units.firstOrNull { it == WeightMeasurementUnit.POUND }
+                ?: WeightMeasurementUnit.POUND
+            return Weight(w, unit)
+        }
+        weightString.endsWith("st") -> {
+            val w = weightString.substringBefore("st").trim().replace(',', '.').toDoubleOrNull()
+                ?: return null
+            val unit = units.firstOrNull { it == WeightMeasurementUnit.SHORT_TON }
+                ?: WeightMeasurementUnit.SHORT_TON
+            return Weight(w, unit)
+        }
+        weightString.endsWith("t") -> {
+            val w = weightString.substringBefore("t").trim().replace(',', '.').toDoubleOrNull()
+                ?: return null
+            return Weight(w, units.firstOrNull() ?: WeightMeasurementUnit.METRIC_TON)
+        }
+        else -> return null
+    }
+}
+
+private fun relationDetailsText(
+    relation: Relation,
+    mapDataSource: MapDataWithEditsSource,
+): String {
+    val tagsText = relation.tags.entries
+        .sortedBy { it.key }
+        .joinToString("\n") { "${it.key} = ${it.value}" }
+    val membersText = relation.members.joinToString("\n") { member ->
+        val element = mapDataSource.get(member.type, member.ref)
+        val details = element?.key?.toString() ?: "${member.type}/${member.ref}"
+        "${member.role}: $details"
+    }
+    return "$tagsText\n\n$membersText"
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/MainScreen.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/MainScreen.kt
@@ -76,6 +76,7 @@ fun MainScreen(
     onClickProfile: () -> Unit,
     onClickLogin: () -> Unit,
     onSetMapMarkers: (Iterable<Marker>) -> Unit,
+    onSetOverlayVisible: (Boolean) -> Unit = {},
     onSolvedQuest: (icon: DrawableResource, position: LatLon) -> Unit,
     getOffset: (position: LatLon) -> Offset?,
     lastMapClick: MapClick?,
@@ -311,6 +312,7 @@ fun MainScreen(
                         mapPosition = mapCamera.position,
                         mapMetersPerDp = metersPerDp,
                         onSetMapMarkers = onSetMapMarkers,
+                        onSetOverlayVisible = onSetOverlayVisible,
                         getOffset = getOffset,
                         lastMapClick = lastMapClick,
                     )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/MainBottomSheet.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/MainBottomSheet.kt
@@ -60,6 +60,7 @@ fun MainBottomSheet(
     mapPosition: LatLon,
     mapMetersPerDp: Double,
     onSetMapMarkers: (Iterable<Marker>) -> Unit,
+    onSetOverlayVisible: (Boolean) -> Unit = {},
     getOffset: (position: LatLon) -> Offset?,
     lastMapClick: MapClick?,
     modifier: Modifier = Modifier
@@ -238,6 +239,7 @@ fun MainBottomSheet(
                 mapPosition = mapPosition,
                 mapMetersPerDp = mapMetersPerDp,
                 onSetMapMarkers = onSetMapMarkers,
+                onSetOverlayVisible = onSetOverlayVisible,
                 getOffset = getOffset,
                 lastMapClick = lastMapClick,
                 modifier = modifier,

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/overlay/OverlayFormContainer.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/overlay/OverlayFormContainer.kt
@@ -40,6 +40,7 @@ import de.westnordost.streetcomplete.ui.common.quest.LocalMapMarkersCallback
 import de.westnordost.streetcomplete.ui.common.quest.LocalMapMetersPerDp
 import de.westnordost.streetcomplete.ui.common.quest.LocalMapRotation
 import de.westnordost.streetcomplete.ui.common.quest.LocalMapTilt
+import de.westnordost.streetcomplete.ui.common.quest.LocalSetOverlayVisibleCallback
 import de.westnordost.streetcomplete.ui.common.quest.MapClick
 import de.westnordost.streetcomplete.ui.common.quest.Marker
 import de.westnordost.streetcomplete.ui.util.ReplaceBottomSheetTransitionSpec
@@ -72,6 +73,7 @@ fun OverlayFormContainer(
     mapPosition: LatLon,
     mapMetersPerDp: Double,
     onSetMapMarkers: (Iterable<Marker>) -> Unit,
+    onSetOverlayVisible: (Boolean) -> Unit = {},
     getOffset: (position: LatLon) -> Offset?,
     lastMapClick: MapClick?,
     modifier: Modifier = Modifier,
@@ -84,8 +86,11 @@ fun OverlayFormContainer(
     var showAccessManager by remember { mutableStateOf(false) }
     var showConstructionDialog by remember { mutableStateOf(false) }
 
-    // markers shown are per-form
-    LaunchedEffect(state) { onSetMapMarkers(emptyList()) }
+    // markers / overlay visibility are per-form
+    LaunchedEffect(state) {
+        onSetMapMarkers(emptyList())
+        onSetOverlayVisible(true)
+    }
 
     fun onAction(action: OverlayAction) {
         when (action) {
@@ -106,6 +111,7 @@ fun OverlayFormContainer(
         LocalMapTilt provides mapTilt,
         LocalMapMetersPerDp provides mapMetersPerDp,
         LocalMapMarkersCallback provides onSetMapMarkers,
+        LocalSetOverlayVisibleCallback provides onSetOverlayVisible,
         LocalGetOffsetCallback provides getOffset,
         LocalLastMapClick provides lastMapClick,
     ) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/CompositionLocals.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/quest/CompositionLocals.kt
@@ -22,6 +22,9 @@ val LocalLastMapClick = compositionLocalOf<MapClick?> { null }
 
 val LocalMapMarkersCallback = compositionLocalOf<((Iterable<Marker>) -> Unit)?> { null }
 
+/** Temporarily show/hide the styleable overlay layer (e.g. during map-selection modes). */
+val LocalSetOverlayVisibleCallback = compositionLocalOf<((Boolean) -> Unit)?> { null }
+
 val LocalGetOffsetCallback = compositionLocalOf<((LatLon) -> Offset?)?> { null }
 
 val LocalIsTagEditor = compositionLocalOf<Boolean> { false }

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayNodeTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayNodeTest.kt
@@ -1,0 +1,254 @@
+package de.westnordost.streetcomplete.overlays.restriction
+
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryChange
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryDelete
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryModify
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
+import de.westnordost.streetcomplete.overlays.restriction.RestrictionNodeDirection.BACKWARD
+import de.westnordost.streetcomplete.overlays.restriction.RestrictionNodeDirection.FORWARD
+import de.westnordost.streetcomplete.overlays.restriction.RestrictionNodeType.ALL_WAY_STOP
+import de.westnordost.streetcomplete.overlays.restriction.RestrictionNodeType.GIVE_WAY
+import de.westnordost.streetcomplete.overlays.restriction.RestrictionNodeType.STOP
+import de.westnordost.streetcomplete.util.math.PositionOnWaySegment
+import de.westnordost.streetcomplete.util.math.VertexOfWay
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RestrictionOverlayNodeTest {
+
+    @Test fun `parse give_way with optional direction`() {
+        assertEquals(GIVE_WAY to null, parseRestrictionNode(mapOf("highway" to "give_way")))
+        assertEquals(
+            GIVE_WAY to FORWARD,
+            parseRestrictionNode(mapOf("highway" to "give_way", "direction" to "forward"))
+        )
+        assertEquals(
+            GIVE_WAY to BACKWARD,
+            parseRestrictionNode(mapOf("highway" to "give_way", "direction" to "backward"))
+        )
+        assertEquals(
+            GIVE_WAY to null,
+            parseRestrictionNode(mapOf("highway" to "give_way", "direction" to "both"))
+        )
+    }
+
+    @Test fun `parse stop`() {
+        assertEquals(STOP to null, parseRestrictionNode(mapOf("highway" to "stop")))
+        assertEquals(
+            STOP to FORWARD,
+            parseRestrictionNode(mapOf("highway" to "stop", "direction" to "forward"))
+        )
+    }
+
+    @Test fun `parse all-way stop`() {
+        assertEquals(
+            ALL_WAY_STOP to null,
+            parseRestrictionNode(mapOf("highway" to "stop", "stop" to "all"))
+        )
+        assertEquals(
+            ALL_WAY_STOP to null,
+            parseRestrictionNode(mapOf("highway" to "stop", "direction" to "both"))
+        )
+        assertEquals(
+            ALL_WAY_STOP to null,
+            parseRestrictionNode(mapOf("highway" to "stop", "stop" to "all", "direction" to "forward"))
+        )
+    }
+
+    @Test fun `parse unsupported node`() {
+        assertEquals(null to null, parseRestrictionNode(emptyMap()))
+        assertEquals(null to null, parseRestrictionNode(mapOf("highway" to "traffic_signals")))
+    }
+
+    @Test fun `create give_way tags`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("highway", "give_way")),
+            GIVE_WAY.appliedTo(emptyMap())
+        )
+        assertEquals(
+            setOf(
+                StringMapEntryAdd("highway", "give_way"),
+                StringMapEntryAdd("direction", "forward"),
+            ),
+            GIVE_WAY.appliedTo(emptyMap(), FORWARD)
+        )
+    }
+
+    @Test fun `create stop tags`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("highway", "stop")),
+            STOP.appliedTo(emptyMap())
+        )
+        assertEquals(
+            setOf(
+                StringMapEntryAdd("highway", "stop"),
+                StringMapEntryAdd("direction", "backward"),
+            ),
+            STOP.appliedTo(emptyMap(), BACKWARD)
+        )
+    }
+
+    @Test fun `create all-way stop tags`() {
+        assertEquals(
+            setOf(
+                StringMapEntryAdd("highway", "stop"),
+                StringMapEntryAdd("stop", "all"),
+            ),
+            ALL_WAY_STOP.appliedTo(emptyMap())
+        )
+        assertEquals(
+            setOf(
+                StringMapEntryAdd("highway", "stop"),
+                StringMapEntryAdd("stop", "all"),
+            ),
+            ALL_WAY_STOP.appliedTo(emptyMap(), FORWARD)
+        )
+    }
+
+    @Test fun `edit give_way to stop keeps direction`() {
+        assertEquals(
+            setOf(StringMapEntryModify("highway", "give_way", "stop")),
+            STOP.appliedTo(mapOf("highway" to "give_way", "direction" to "forward"), FORWARD)
+        )
+    }
+
+    @Test fun `edit stop to give_way removes stop tag`() {
+        assertEquals(
+            setOf(
+                StringMapEntryModify("highway", "stop", "give_way"),
+                StringMapEntryDelete("stop", "all"),
+            ),
+            GIVE_WAY.appliedTo(mapOf("highway" to "stop", "stop" to "all"))
+        )
+    }
+
+    @Test fun `edit stop to all-way stop removes direction`() {
+        assertEquals(
+            setOf(
+                StringMapEntryDelete("direction", "forward"),
+                StringMapEntryAdd("stop", "all"),
+            ),
+            ALL_WAY_STOP.appliedTo(mapOf("highway" to "stop", "direction" to "forward"))
+        )
+    }
+
+    @Test fun `edit all-way stop to stop does not remove stop=all`() {
+        // historical applyTo only removes stop when switching to give_way
+        assertEquals(
+            emptySet(),
+            STOP.appliedTo(mapOf("highway" to "stop", "stop" to "all"))
+        )
+    }
+
+    @Test fun `resolve stop to all-way stop on multi-way vertex`() {
+        assertEquals(ALL_WAY_STOP, resolveRestrictionNodeType(STOP, 2))
+        assertEquals(ALL_WAY_STOP, resolveRestrictionNodeType(STOP, 3))
+        assertEquals(STOP, resolveRestrictionNodeType(STOP, 1))
+        assertEquals(STOP, resolveRestrictionNodeType(STOP, null))
+    }
+
+    @Test fun `resolve all-way stop to stop on single way`() {
+        assertEquals(STOP, resolveRestrictionNodeType(ALL_WAY_STOP, 1))
+        assertEquals(STOP, resolveRestrictionNodeType(ALL_WAY_STOP, null))
+        assertEquals(ALL_WAY_STOP, resolveRestrictionNodeType(ALL_WAY_STOP, 2))
+    }
+
+    @Test fun `give_way is not auto-converted at intersections`() {
+        assertEquals(GIVE_WAY, resolveRestrictionNodeType(GIVE_WAY, 2))
+        assertNull(resolveRestrictionNodeType(null, 2))
+    }
+
+    @Test fun `give_way cannot be placed on multi-way vertex`() {
+        val pos = VertexOfWay(setOf(1L, 2L), LatLon(0.0, 0.0), 10L)
+        assertNull(positionOnWayForRestrictionNode(GIVE_WAY, pos, 2, emptyMap()))
+        assertEquals(pos, positionOnWayForRestrictionNode(GIVE_WAY, pos, 1, emptyMap()))
+        assertEquals(pos, positionOnWayForRestrictionNode(STOP, pos, 2, emptyMap()))
+    }
+
+    @Test fun `cannot snap onto existing highway or crossing vertex`() {
+        val pos = VertexOfWay(setOf(1L), LatLon(0.0, 0.0), 10L)
+        assertNull(positionOnWayForRestrictionNode(STOP, pos, 1, mapOf("highway" to "crossing")))
+        assertNull(positionOnWayForRestrictionNode(STOP, pos, 1, mapOf("crossing" to "unmarked")))
+        assertEquals(pos, positionOnWayForRestrictionNode(STOP, pos, 1, emptyMap()))
+        assertNull(positionOnWayForRestrictionNode(STOP, pos, 1, null))
+        val onSegment = PositionOnWaySegment(1L, LatLon(0.0, 0.0), LatLon(0.0, 0.0) to LatLon(0.001, 0.0))
+        assertEquals(onSegment, positionOnWayForRestrictionNode(STOP, onSegment, null, mapOf("highway" to "stop")))
+    }
+
+    @Test fun `two ways sharing only an end node count as one way`() {
+        val way1 = Way(1, listOf(1, 2, 3))
+        val way2 = Way(2, listOf(3, 4, 5))
+        val roads = listOf(way1 to emptyList<LatLon>(), way2 to emptyList())
+        assertEquals(1, wayCountOnVertex(3, roads))
+        assertEquals(1, wayCountOnVertex(1, roads))
+        assertEquals(2, wayCountOnVertex(3, listOf(
+            Way(1, listOf(1, 2, 3, 4)) to emptyList<LatLon>(),
+            Way(2, listOf(10, 3, 20)) to emptyList(),
+        )))
+    }
+
+    @Test fun `direction chooser hidden on oneway roads unless cyclists are excepted`() {
+        assertFalse(shouldShowRestrictionNodeDirection(
+            wayTags = mapOf("highway" to "residential", "oneway" to "yes"),
+            isLeftHandTraffic = false,
+            isMultiWayVertex = false,
+        ))
+        assertTrue(shouldShowRestrictionNodeDirection(
+            wayTags = mapOf("highway" to "residential", "oneway" to "yes", "oneway:bicycle" to "no"),
+            isLeftHandTraffic = false,
+            isMultiWayVertex = false,
+        ))
+        assertTrue(shouldShowRestrictionNodeDirection(
+            wayTags = mapOf("highway" to "residential"),
+            isLeftHandTraffic = false,
+            isMultiWayVertex = false,
+        ))
+        assertFalse(shouldShowRestrictionNodeDirection(
+            wayTags = mapOf("highway" to "residential"),
+            isLeftHandTraffic = false,
+            isMultiWayVertex = true,
+        ))
+    }
+
+    @Test fun `direction chooser on cycleways ignores bicycle-contraflow exception`() {
+        assertFalse(shouldShowRestrictionNodeDirection(
+            wayTags = mapOf("highway" to "cycleway", "oneway" to "yes"),
+            isLeftHandTraffic = false,
+            isMultiWayVertex = false,
+        ))
+        assertFalse(shouldShowRestrictionNodeDirection(
+            wayTags = mapOf("highway" to "cycleway", "oneway:bicycle" to "yes"),
+            isLeftHandTraffic = false,
+            isMultiWayVertex = false,
+        ))
+        assertTrue(shouldShowRestrictionNodeDirection(
+            wayTags = mapOf("highway" to "cycleway"),
+            isLeftHandTraffic = false,
+            isMultiWayVertex = false,
+        ))
+    }
+
+    @Test fun `bearing follows the way direction at a node`() {
+        val south = LatLon(0.0, 0.0)
+        val north = LatLon(0.001, 0.0)
+        val nodeIds = listOf(1L, 2L)
+        val positions = mapOf(1L to south, 2L to north)
+
+        val atStart = bearingAlongWayAtIndex(south, 0, nodeIds) { positions[it] }
+        val atEnd = bearingAlongWayAtIndex(north, 1, nodeIds) { positions[it] }
+        assertEquals(0.0, atStart, 1.0)
+        assertEquals(0.0, atEnd, 1.0)
+    }
+}
+
+private fun RestrictionNodeType.appliedTo(
+    tags: Map<String, String>,
+    direction: RestrictionNodeDirection? = null,
+): Set<StringMapEntryChange> =
+    StringMapChangesBuilder(tags).also { applyTo(it, direction) }.create().changes

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayStyleTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayStyleTest.kt
@@ -1,0 +1,33 @@
+package de.westnordost.streetcomplete.overlays.restriction
+
+import de.westnordost.streetcomplete.data.overlays.OverlayStyle
+import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.resources.ic_restriction_give_way
+import de.westnordost.streetcomplete.resources.ic_restriction_stop
+import de.westnordost.streetcomplete.testutils.TestMapDataWithGeometry
+import de.westnordost.streetcomplete.testutils.node
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class RestrictionOverlayStyleTest {
+
+    private val overlay = RestrictionOverlay()
+
+    @Test fun `stop and give_way nodes get point styles with icons`() {
+        val stop = node(1, tags = mapOf("highway" to "stop"))
+        val giveWay = node(2, tags = mapOf("highway" to "give_way"))
+        val other = node(3, tags = mapOf("highway" to "traffic_signals"))
+        val mapData = TestMapDataWithGeometry(listOf(stop, giveWay, other))
+
+        val styles = overlay.getStyledElements(mapData).associate { it.first.id to it.second }
+
+        val stopStyle = assertIs<OverlayStyle.Point>(styles[1])
+        assertEquals(Res.drawable.ic_restriction_stop, stopStyle.icon)
+
+        val giveWayStyle = assertIs<OverlayStyle.Point>(styles[2])
+        assertEquals(Res.drawable.ic_restriction_give_way, giveWayStyle.icon)
+
+        assertEquals(null, styles[3])
+    }
+}

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWayTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWayTest.kt
@@ -1,0 +1,226 @@
+package de.westnordost.streetcomplete.overlays.restriction
+
+import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.mapdata.Relation
+import de.westnordost.streetcomplete.data.osm.mapdata.RelationMember
+import de.westnordost.streetcomplete.quests.max_weight.MaxWeightType
+import de.westnordost.streetcomplete.testutils.node
+import de.westnordost.streetcomplete.testutils.rel
+import de.westnordost.streetcomplete.testutils.way
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RestrictionOverlayWayTest {
+
+    @Test fun `getShortRestrictionValue prefers restriction then conditional then vehicle`() {
+        assertEquals("no_left_turn", mapOf("restriction" to "no_left_turn").getShortRestrictionValue())
+        assertEquals(
+            "only_straight_on",
+            mapOf("restriction:conditional" to "only_straight_on @ (Mo-Fr)").getShortRestrictionValue()
+        )
+        assertEquals(
+            "no_u_turn",
+            mapOf("restriction:hgv" to "no_u_turn").getShortRestrictionValue()
+        )
+        assertNull(emptyMap<String, String>().getShortRestrictionValue())
+    }
+
+    @Test fun `getWeightRestrictions finds plain and conditional keys`() {
+        val way = way(tags = mapOf(
+            "highway" to "secondary",
+            "maxweight" to "7.5",
+            "maxaxleload:conditional" to "8 @ (wet)",
+        ))
+        val restrictions = getWeightRestrictions(way)
+        assertEquals(2, restrictions.size)
+        assertTrue(restrictions.any { it.type == MaxWeightType.MAX_WEIGHT && it.weight == "7.5" })
+        assertTrue(restrictions.any { it.type == MaxWeightType.MAX_AXLE_LOAD })
+    }
+
+    @Test fun `createTurnRestrictionRelation uses from via to roles`() {
+        val from = way(1, nodes = listOf(1, 2))
+        val to = way(2, nodes = listOf(2, 3))
+        val via = node(2, LatLon(1.0, 2.0))
+        val relation = createTurnRestrictionRelation(
+            fromWay = from,
+            toWay = to,
+            viaNode = via,
+            restrictionType = "no_left_turn",
+            signed = true,
+        )
+        assertEquals(0L, relation.id)
+        assertEquals("restriction", relation.tags["type"])
+        assertEquals("no_left_turn", relation.tags["restriction"])
+        assertNull(relation.tags["explicit"])
+        assertEquals(
+            listOf(
+                RelationMember(ElementType.WAY, 1, "from"),
+                RelationMember(ElementType.WAY, 2, "to"),
+                RelationMember(ElementType.NODE, 2, "via"),
+            ),
+            relation.members
+        )
+    }
+
+    @Test fun `createTurnRestrictionRelation marks unsigned with explicit=yes`() {
+        val relation = createTurnRestrictionRelation(
+            fromWay = way(1, nodes = listOf(1, 2)),
+            toWay = way(2, nodes = listOf(2, 3)),
+            viaNode = node(2),
+            restrictionType = "only_right_turn",
+            signed = false,
+        )
+        assertEquals("yes", relation.tags["explicit"])
+    }
+
+    @Test fun `withTurnRestrictionType updates plain restriction`() {
+        val relation = rel(tags = mapOf("type" to "restriction", "restriction" to "no_left_turn"))
+        assertEquals(
+            "no_right_turn",
+            withTurnRestrictionType(relation, "no_right_turn").tags["restriction"]
+        )
+    }
+
+    @Test fun `withTurnRestrictionType updates conditional-only restriction`() {
+        val relation = rel(tags = mapOf(
+            "type" to "restriction",
+            "restriction:conditional" to "no_left_turn @ (Mo-Fr)",
+        ))
+        val updated = withTurnRestrictionType(relation, "no_u_turn")
+        assertEquals("no_u_turn @ (Mo-Fr)", updated.tags["restriction:conditional"])
+    }
+
+    @Test fun `withSwappedFromTo swaps roles`() {
+        val relation = Relation(
+            id = 1,
+            members = listOf(
+                RelationMember(ElementType.WAY, 10, "from"),
+                RelationMember(ElementType.WAY, 20, "to"),
+                RelationMember(ElementType.NODE, 30, "via"),
+            ),
+            tags = mapOf("type" to "restriction", "restriction" to "no_left_turn"),
+        )
+        val swapped = withSwappedFromTo(relation)
+        assertEquals("to", swapped.members[0].role)
+        assertEquals("from", swapped.members[1].role)
+        assertEquals("via", swapped.members[2].role)
+    }
+
+    @Test fun `withExceptions writes and clears except tag`() {
+        val relation = rel(tags = mapOf("type" to "restriction", "restriction" to "no_u_turn"))
+        assertEquals(
+            "bicycle;bus",
+            withExceptions(relation, listOf("bicycle", "bus")).tags["except"]
+        )
+        assertNull(withExceptions(relation, emptyList()).tags["except"])
+    }
+
+    @Test fun `withOnlyFor moves restriction to vehicle key`() {
+        val relation = rel(tags = mapOf("type" to "restriction", "restriction" to "no_left_turn"))
+        val hgv = withOnlyFor(relation, "hgv")
+        assertNull(hgv.tags["restriction"])
+        assertEquals("no_left_turn", hgv.tags["restriction:hgv"])
+
+        val cleared = withOnlyFor(hgv, null)
+        assertEquals("no_left_turn", cleared.tags["restriction"])
+        assertNull(cleared.tags["restriction:hgv"])
+    }
+
+    @Test fun `withImplicitSigned toggles implicit tag`() {
+        val relation = rel(tags = mapOf("type" to "restriction", "restriction" to "no_u_turn"))
+        assertEquals("yes", withImplicitSigned(relation, signed = false).tags["implicit"])
+        assertNull(withImplicitSigned(relation, signed = true).tags["implicit"])
+    }
+
+    @Test fun `getInitialRestrictionPreferComplete prefers supported complete turn`() {
+        val supported = TurnRestriction(
+            rel(
+                id = 1,
+                members = listOf(
+                    RelationMember(ElementType.WAY, 1, "from"),
+                    RelationMember(ElementType.WAY, 2, "to"),
+                    RelationMember(ElementType.NODE, 3, "via"),
+                ),
+                tags = mapOf("type" to "restriction", "restriction" to "no_left_turn"),
+            )
+        )
+        val weight = WeightRestriction(way(tags = mapOf("maxweight" to "5")), MaxWeightType.MAX_WEIGHT, "5")
+        val incomplete = TurnRestriction(
+            rel(
+                id = 2,
+                members = listOf(
+                    RelationMember(ElementType.WAY, 1, "from"),
+                    RelationMember(ElementType.WAY, 2, "to"),
+                    RelationMember(ElementType.NODE, 3, "via"),
+                ),
+                tags = mapOf("type" to "restriction", "restriction" to "no_right_turn"),
+            )
+        )
+        assertEquals(
+            supported,
+            getInitialRestrictionPreferComplete(listOf(incomplete, weight, supported)) { it.id == 1L }
+        )
+        assertEquals(
+            weight,
+            getInitialRestrictionPreferComplete(listOf(incomplete, weight)) { false }
+        )
+    }
+
+    @Test fun `isSupportedTurnRestriction validates members and type`() {
+        assertTrue(
+            rel(
+                members = listOf(
+                    RelationMember(ElementType.WAY, 1, "from"),
+                    RelationMember(ElementType.WAY, 2, "to"),
+                    RelationMember(ElementType.NODE, 3, "via"),
+                ),
+                tags = mapOf("type" to "restriction", "restriction" to "no_left_turn"),
+            ).isSupportedTurnRestriction()
+        )
+        // Historical: missing via still counts as "supported type shape" (completeness is separate)
+        assertTrue(
+            rel(
+                members = listOf(
+                    RelationMember(ElementType.WAY, 1, "from"),
+                    RelationMember(ElementType.WAY, 2, "to"),
+                ),
+                tags = mapOf("type" to "restriction", "restriction" to "no_left_turn"),
+            ).isSupportedTurnRestriction()
+        )
+        assertFalse(
+            rel(
+                members = listOf(
+                    RelationMember(ElementType.WAY, 1, "from"),
+                    RelationMember(ElementType.WAY, 2, "to"),
+                    RelationMember(ElementType.NODE, 3, "via"),
+                ),
+                tags = mapOf("type" to "restriction", "restriction" to "no_entry"),
+            ).isSupportedTurnRestriction()
+        )
+        assertFalse(
+            rel(
+                members = listOf(
+                    RelationMember(ElementType.WAY, 1, "from"),
+                    RelationMember(ElementType.WAY, 2, "to"),
+                    RelationMember(ElementType.NODE, 3, "via"),
+                    RelationMember(ElementType.WAY, 4, "via"),
+                ),
+                tags = mapOf("type" to "restriction", "restriction" to "no_left_turn"),
+            ).isSupportedTurnRestriction()
+        )
+    }
+
+    @Test fun `getIconForTurnRestriction covers supported types`() {
+        assertNotNull(getIconForTurnRestriction("no_left_turn"))
+        assertNotNull(getIconForTurnRestriction("only_straight_on"))
+        assertEquals(
+            getIconForTurnRestriction(null),
+            getIconForTurnRestriction("something_else")
+        )
+    }
+}

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWayTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/restriction/RestrictionOverlayWayTest.kt
@@ -109,6 +109,68 @@ class RestrictionOverlayWayTest {
         assertEquals("to", swapped.members[0].role)
         assertEquals("from", swapped.members[1].role)
         assertEquals("via", swapped.members[2].role)
+        assertEquals(10L, swapped.members[0].ref)
+        assertEquals(20L, swapped.members[1].ref)
+    }
+
+    @Test fun `from to swap allowed only for draft relations`() {
+        val draft = createTurnRestrictionRelation(
+            fromWay = way(1, nodes = listOf(1, 2)),
+            toWay = way(2, nodes = listOf(2, 3)),
+            viaNode = node(2),
+            restrictionType = "no_left_turn",
+            signed = true,
+        )
+        assertTrue(isTurnRestrictionFromToSwapAllowed(draft))
+        assertFalse(
+            isTurnRestrictionFromToSwapAllowed(
+                draft.copy(id = 42L)
+            )
+        )
+    }
+
+    @Test fun `draft swap updates roles used for create and way role helper`() {
+        val from = way(10, nodes = listOf(1, 2))
+        val to = way(20, nodes = listOf(2, 3))
+        val draft = createTurnRestrictionRelation(
+            fromWay = from,
+            toWay = to,
+            viaNode = node(2),
+            restrictionType = "only_right_turn",
+            signed = true,
+        )
+        assertEquals("from", wayRoleInTurnRestriction(draft, from.id))
+        assertEquals("to", wayRoleInTurnRestriction(draft, to.id))
+
+        val swapped = withSwappedFromTo(draft)
+        assertTrue(isTurnRestrictionFromToSwapAllowed(swapped))
+        assertEquals("to", wayRoleInTurnRestriction(swapped, from.id))
+        assertEquals("from", wayRoleInTurnRestriction(swapped, to.id))
+        assertEquals(
+            listOf(
+                RelationMember(ElementType.WAY, 10, "to"),
+                RelationMember(ElementType.WAY, 20, "from"),
+                RelationMember(ElementType.NODE, 2, "via"),
+            ),
+            swapped.members
+        )
+    }
+
+    @Test fun `existing relation swap helper still swaps members but is not allowed in UI`() {
+        val existing = rel(
+            id = 99,
+            members = listOf(
+                RelationMember(ElementType.WAY, 1, "from"),
+                RelationMember(ElementType.WAY, 2, "to"),
+                RelationMember(ElementType.NODE, 3, "via"),
+            ),
+            tags = mapOf("type" to "restriction", "restriction" to "no_u_turn"),
+        )
+        assertFalse(isTurnRestrictionFromToSwapAllowed(existing))
+        val swapped = withSwappedFromTo(existing)
+        assertEquals("to", swapped.members[0].role)
+        assertEquals("from", swapped.members[1].role)
+        assertEquals(99L, swapped.id)
     }
 
     @Test fun `withExceptions writes and clears except tag`() {


### PR DESCRIPTION
Restores the SCEE traffic restriction overlay after the StreetComplete Compose migration.

- migrates the node form for stop/give_way/all-way stop
- migrates the way form for turn restrictions and maxweight
- restores creation/editing/deletion of restriction relations
- replaces the old hideOverlay() behavior with a Compose callback
- fixes Android icon mapping for restriction overlay icons

Tested with:
- :app:copyIconsToAndroid
- :app:compileAndroidMain
- :androidApp:compileDebugKotlin
- 35 restriction overlay host tests
- manual testing of node and way forms

Fixes #915 

<img width="454" height="945" alt="grafik" src="https://github.com/user-attachments/assets/4d6eafce-0a28-4520-8129-3a7f2f2e6d37" />
<img width="475" height="481" alt="grafik" src="https://github.com/user-attachments/assets/a396df7f-35b0-475f-8dd1-c9e406b1ca33" />
<img width="462" height="468" alt="grafik" src="https://github.com/user-attachments/assets/571d3930-6040-4e02-b37a-fb09bd7332df" />
