### PR TITLE
Add is_sidepath quest with road association

### DIFF
--- a/app/src/commonMain/composeResources/values/strings_ee.xml
+++ b/app/src/commonMain/composeResources/values/strings_ee.xml
@@ -673,6 +673,16 @@
     <!-- bicycle oneway -->
     <string name="quest_onewayBicycle_title">Is this path one-way for bicycles? In which direction?</string>
 
+    <!-- is_sidepath -->
+    <string name="quest_is_sidepath_title">Does this path run along a road?</string>
+    <string name="quest_is_sidepath_hint">A sidepath runs adjacent and parallel to a road so that you would describe movement as “along &lt;road name&gt;”. If the path goes through a park, forest or otherwise independent corridor, answer “No”.</string>
+    <string name="quest_is_sidepath_answer_is_sidewalk">This is a sidewalk.</string>
+    <string name="quest_is_sidepath_answer_is_crossing">This is a crossing.</string>
+    <string name="quest_is_sidepath_road_title">Which road does this path run along?</string>
+    <string name="quest_is_sidepath_road_cant_say">Can’t say</string>
+    <string name="quest_is_sidepath_road_loading">Looking for nearby roads…</string>
+    <string name="quest_is_sidepath_unnamed_road">Unnamed %1$s</string>
+
     <!-- toilets disposal quest -->
     <string name="quest_toilets_disposal_title">What kind of toilet disposal is used here?</string>
     <string name="quest_toilets_disposal_flush">The waste is flushed with water</string>

--- a/app/src/commonMain/composeResources/values/strings_ee.xml
+++ b/app/src/commonMain/composeResources/values/strings_ee.xml
@@ -676,7 +676,8 @@
     <!-- is_sidepath -->
     <string name="quest_is_sidepath_title">Does this path run along a road?</string>
     <string name="quest_is_sidepath_hint">A sidepath runs adjacent and parallel to a road so that you would describe movement as “along &lt;road name&gt;”. If the path goes through a park, forest or otherwise independent corridor, answer “No”.</string>
-    <string name="quest_is_sidepath_answer_is_sidewalk">This is a sidewalk.</string>
+    <string name="quest_is_sidepath_answer_sidewalk">Yes, this is a sidewalk</string>
+    <string name="quest_is_sidepath_answer_parallel_path">Yes, this is a parallel path</string>
     <string name="quest_is_sidepath_answer_is_crossing">This is a crossing.</string>
     <string name="quest_is_sidepath_road_title">Which road does this path run along?</string>
     <string name="quest_is_sidepath_road_cant_say">Can’t say</string>

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestUtils.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestUtils.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.data.osm.osmquests
 import de.westnordost.streetcomplete.quests.address.AddHousenumber
 import de.westnordost.streetcomplete.quests.cycleway.AddCycleway
 import de.westnordost.streetcomplete.quests.existence.CheckExistence
+import de.westnordost.streetcomplete.quests.is_sidepath.AddIsSidepath
 import de.westnordost.streetcomplete.quests.max_height.AddMaxHeight
 import de.westnordost.streetcomplete.quests.opening_hours.AddOpeningHours
 import de.westnordost.streetcomplete.quests.place_name.AddPlaceName
@@ -18,6 +19,7 @@ fun getAnalyzePriority(questType: OsmElementQuestType<*>): Int = when (questType
     is CheckShopExistence -> 1 // FeatureDictionary, extensive filter
     is AddHousenumber -> 1 // complex filter
     is AddMaxHeight -> 1 // complex filter
+    is AddIsSidepath -> 1 // path↔road geometry distance + alignment
     is AddCycleway -> 2 // complex filter
     is AddPlaceName -> 2 // FeatureDictionary, extensive filter
     else -> 10

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/QuestTypesRegistry.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/QuestTypesRegistry.kt
@@ -128,6 +128,7 @@ import de.westnordost.streetcomplete.quests.handwashing.AddHandwashing
 import de.westnordost.streetcomplete.quests.incline_direction.AddBicycleIncline
 import de.westnordost.streetcomplete.quests.incline_direction.AddStepsIncline
 import de.westnordost.streetcomplete.quests.internet_access.AddInternetAccess
+import de.westnordost.streetcomplete.quests.is_sidepath.AddIsSidepath
 import de.westnordost.streetcomplete.quests.kerb_height.AddKerbHeight
 import de.westnordost.streetcomplete.quests.kerb_type.AddKerbType
 import de.westnordost.streetcomplete.quests.lamp_type.AddLampType
@@ -692,6 +693,7 @@ fun getQuestTypeList(
     EE_QUEST_OFFSET + 55 to AddPostOfficeType(),
     EE_QUEST_OFFSET + 57 to AddLampMount(),
     EE_QUEST_OFFSET + 58 to AddOnewayBicycle(),
+    EE_QUEST_OFFSET + 201 to AddIsSidepath(),
     EE_QUEST_OFFSET + 62 to AddToiletsDisposal(),
     EE_QUEST_OFFSET + 63 to AddEvseId(),
     EE_QUEST_OFFSET + 66 to AddServiceTimes(),

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/AddIsSidepath.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/AddIsSidepath.kt
@@ -1,0 +1,125 @@
+package de.westnordost.streetcomplete.quests.is_sidepath
+
+import androidx.compose.runtime.Composable
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
+import de.westnordost.streetcomplete.data.meta.CountryInfo
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
+import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.quests.FullElementSelectionDialog
+import de.westnordost.streetcomplete.quests.getPrefixedFullElementSelectionPref
+import de.westnordost.streetcomplete.resources.*
+
+class AddIsSidepath : OsmElementQuestType<IsSidepathAnswer> {
+
+    private val elementFilter = """
+        ways with
+          (
+            (
+              highway = cycleway
+              and cycleway !~ sidewalk|link|sidepath|crossing
+            )
+            or
+            (
+              highway = footway
+              and footway !~ sidewalk|link|crossing
+            )
+            or
+            (
+              highway = path
+              and (bicycle or foot)
+              and path !~ sidewalk|link|crossing|sidepath
+            )
+          )
+          and !is_sidepath
+          and area != yes
+          and access !~ no|private
+    """.trimIndent()
+
+    private val filter by lazy {
+        prefs
+            .getString(getPrefixedFullElementSelectionPref(prefs), elementFilter)
+            .toElementFilterExpression()
+    }
+
+    override val changesetComment = "Specify whether a path is a sidepath of a road"
+    override val wikiLink = "Key:is_sidepath"
+    override val icon = Res.drawable.ic_quest_poi_bicycle
+    override val hint = Res.string.quest_is_sidepath_hint
+    override val defaultDisabledMessage = Res.string.default_disabled_msg_ee
+    override val title = Res.string.quest_is_sidepath_title
+    override val hasQuestSettings = true
+
+    @Composable
+    override fun QuestSettings(onDismissRequest: () -> Unit) {
+        FullElementSelectionDialog(
+            prefs,
+            getPrefixedFullElementSelectionPref(prefs),
+            Res.string.quest_settings_element_selection,
+            elementFilter,
+            onDismissRequest
+        )
+    }
+
+    override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> =
+        mapData.ways.filter { path ->
+            if (!filter.matches(path)) return@filter false
+            val geometry = mapData.getWayGeometry(path.id) ?: return@filter false
+            hasNearbyAlignedRoad(geometry, mapData)
+        }
+
+    /**
+     * Tag filter only. Geometry gating runs in [getApplicableElements] on download.
+     * Returning null here would re-fetch only path.bounds+20m and can miss long sparse roads,
+     * making the quest disappear after updates.
+     */
+    override fun isApplicableTo(element: Element): Boolean = filter.matches(element)
+
+    @Composable
+    override fun Form(
+        on: (QuestAction<IsSidepathAnswer>) -> Unit,
+        element: Element,
+        geometry: ElementGeometry,
+        countryInfo: CountryInfo
+    ) {
+        AddIsSidepathForm(
+            on = on,
+            element = element,
+            geometry = geometry,
+        )
+    }
+
+    override fun applyAnswerTo(
+        answer: IsSidepathAnswer,
+        tags: Tags,
+        geometry: ElementGeometry,
+        timestampEdited: Long
+    ) {
+        when (answer) {
+            is IsSidepathAnswer.Yes -> {
+                tags["is_sidepath"] = "yes"
+                val ofName = answer.ofName
+                if (!ofName.isNullOrEmpty()) {
+                    tags["is_sidepath:of:name"] = ofName
+                }
+            }
+
+            IsSidepathAnswer.No ->
+                tags["is_sidepath"] = "no"
+
+            IsSidepathAnswer.IsSidewalk ->
+                tags["footway"] = "sidewalk"
+
+            IsSidepathAnswer.IsCrossing -> {
+                when (tags["highway"]) {
+                    "cycleway" -> tags["cycleway"] = "crossing"
+                    "footway" -> tags["footway"] = "crossing"
+                    "path" -> tags["path"] = "crossing"
+                }
+            }
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/AddIsSidepathForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/AddIsSidepathForm.kt
@@ -1,0 +1,232 @@
+package de.westnordost.streetcomplete.quests.is_sidepath
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.backhandler.BackHandler
+import androidx.compose.ui.unit.dp
+import de.westnordost.osmfeatures.FeatureDictionary
+import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.osmquests.Answer
+import de.westnordost.streetcomplete.data.osm.osmquests.QuestAction
+import de.westnordost.streetcomplete.resources.*
+import de.westnordost.streetcomplete.screens.main.map.getIcon
+import de.westnordost.streetcomplete.screens.main.map.getTitle
+import de.westnordost.streetcomplete.ui.common.RadioGroup
+import de.westnordost.streetcomplete.ui.common.quest.AnswerItem
+import de.westnordost.streetcomplete.ui.common.quest.LocalMapMarkersCallback
+import de.westnordost.streetcomplete.ui.common.quest.Marker
+import de.westnordost.streetcomplete.ui.common.quest.QuestForm
+import de.westnordost.streetcomplete.ui.util.rememberSerializable
+import de.westnordost.streetcomplete.util.getNameLabel
+import de.westnordost.streetcomplete.util.ktx.getFeature
+import de.westnordost.streetcomplete.util.math.enlargedBy
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+
+@Composable
+fun AddIsSidepathForm(
+    on: (QuestAction<IsSidepathAnswer>) -> Unit,
+    element: Element,
+    geometry: ElementGeometry,
+    mapDataSource: MapDataWithEditsSource = koinInject(),
+    featureDictionary: FeatureDictionary = koinInject(),
+) {
+    var step by rememberSaveable { mutableStateOf(IsSidepathFormStep.AskIfSidepath) }
+
+    when (step) {
+        IsSidepathFormStep.AskIfSidepath -> {
+            QuestForm(
+                on = on,
+                answers = listOf(
+                    AnswerItem(stringResource(Res.string.quest_generic_hasFeature_yes)) {
+                        step = IsSidepathFormStep.ChooseRoad
+                    },
+                    AnswerItem(stringResource(Res.string.quest_generic_hasFeature_no)) {
+                        on(Answer(IsSidepathAnswer.No))
+                    },
+                ),
+                otherAnswers = {
+                    listOfNotNull(
+                        if (element.tags["highway"] == "footway") {
+                            AnswerItem(
+                                stringResource(Res.string.quest_is_sidepath_answer_is_sidewalk)
+                            ) {
+                                on(Answer(IsSidepathAnswer.IsSidewalk))
+                            }
+                        } else {
+                            null
+                        },
+                        AnswerItem(
+                            stringResource(Res.string.quest_is_sidepath_answer_is_crossing)
+                        ) {
+                            on(Answer(IsSidepathAnswer.IsCrossing))
+                        },
+                    )
+                }
+            )
+        }
+
+        IsSidepathFormStep.ChooseRoad -> {
+            ChooseRoadForm(
+                on = on,
+                pathGeometry = geometry,
+                mapDataSource = mapDataSource,
+                featureDictionary = featureDictionary,
+                onBack = { step = IsSidepathFormStep.AskIfSidepath },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun ChooseRoadForm(
+    on: (QuestAction<IsSidepathAnswer>) -> Unit,
+    pathGeometry: ElementGeometry,
+    mapDataSource: MapDataWithEditsSource,
+    featureDictionary: FeatureDictionary,
+    onBack: () -> Unit,
+) {
+    var candidates by rememberSerializable {
+        mutableStateOf<List<CandidateRoad>>(emptyList())
+    }
+    var loaded by rememberSaveable { mutableStateOf(false) }
+    var selection by rememberSerializable {
+        mutableStateOf<SidepathRoadSelection?>(null)
+    }
+
+    LaunchedEffect(pathGeometry.center) {
+        loaded = false
+        val bbox = pathGeometry.bounds.enlargedBy(
+            MAX_SIDEPATH_DISTANCE_METERS + SIDEPATH_MAP_DATA_QUERY_PADDING_METERS
+        )
+        val mapData = withContext(Dispatchers.IO) {
+            mapDataSource.getMapDataWithGeometry(bbox)
+        }
+        candidates = findCandidateRoads(pathGeometry, mapData)
+        loaded = true
+    }
+
+    val mapMarkersCallback = LocalMapMarkersCallback.current
+    LaunchedEffect(selection, candidates) {
+        val selectedId = (selection as? SidepathRoadSelection.Road)?.elementId
+        val markers = if (selectedId == null) {
+            emptyList()
+        } else {
+            candidates.filter { it.element.id == selectedId }.map { candidate ->
+                Marker(
+                    geometry = candidate.geometry,
+                    icon = getIcon(featureDictionary, candidate.element),
+                    title = getTitle(candidate.element.tags),
+                )
+            }
+        }
+        mapMarkersCallback?.invoke(markers)
+    }
+
+    fun clearAndGoBack() {
+        selection = null
+        mapMarkersCallback?.invoke(emptyList())
+        onBack()
+    }
+
+    QuestForm(
+        on = on,
+        title = stringResource(Res.string.quest_is_sidepath_road_title),
+        isComplete = loaded && selection != null,
+        hasChanges = selection != null,
+        onClickOk = {
+            when (val selected = selection) {
+                is SidepathRoadSelection.Road -> {
+                    val name = candidates
+                        .firstOrNull { it.element.id == selected.elementId }
+                        ?.name
+                    on(Answer(IsSidepathAnswer.Yes(ofName = name)))
+                }
+                SidepathRoadSelection.CantSay, null ->
+                    on(Answer(IsSidepathAnswer.Yes(ofName = null)))
+            }
+        },
+    ) {
+        if (!loaded) {
+            Text(stringResource(Res.string.quest_is_sidepath_road_loading))
+        } else {
+            val options = buildList {
+                addAll(candidates.map { SidepathRoadSelection.Road(it.element.id) })
+                add(SidepathRoadSelection.CantSay)
+            }
+            RadioGroup(
+                options = options,
+                onSelectionChange = { selection = it },
+                selectedOption = selection,
+                itemContent = { option ->
+                    when (option) {
+                        is SidepathRoadSelection.Road -> {
+                            val candidate = candidates.first { it.element.id == option.elementId }
+                            CandidateRoadLabel(candidate, featureDictionary)
+                        }
+                        SidepathRoadSelection.CantSay -> {
+                            Text(stringResource(Res.string.quest_is_sidepath_road_cant_say))
+                        }
+                    }
+                },
+            )
+        }
+    }
+
+    // After QuestForm so this takes precedence over form dismiss / discard.
+    BackHandler { clearAndGoBack() }
+}
+
+@Composable
+private fun CandidateRoadLabel(
+    candidate: CandidateRoad,
+    featureDictionary: FeatureDictionary,
+) {
+    val nameLabel = getNameLabel(candidate.element.tags)
+    val featureName = featureDictionary.getFeature(candidate.element)?.name
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        if (nameLabel != null) {
+            Text(nameLabel)
+            if (featureName != null) {
+                Text(
+                    text = featureName,
+                    style = MaterialTheme.typography.body2,
+                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.7f),
+                )
+            }
+        } else if (featureName != null) {
+            Text(stringResource(Res.string.quest_is_sidepath_unnamed_road, featureName))
+        } else {
+            Text(stringResource(Res.string.quest_is_sidepath_unnamed_road, candidate.highway ?: "road"))
+        }
+    }
+}
+
+private enum class IsSidepathFormStep {
+    AskIfSidepath,
+    ChooseRoad,
+}
+
+@Serializable
+private sealed interface SidepathRoadSelection {
+    @Serializable
+    data class Road(val elementId: Long) : SidepathRoadSelection
+    @Serializable
+    data object CantSay : SidepathRoadSelection
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/AddIsSidepathForm.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/AddIsSidepathForm.kt
@@ -50,10 +50,18 @@ fun AddIsSidepathForm(
 
     when (step) {
         IsSidepathFormStep.AskIfSidepath -> {
+            val isFootway = element.tags["highway"] == "footway"
             QuestForm(
                 on = on,
-                answers = listOf(
-                    AnswerItem(stringResource(Res.string.quest_generic_hasFeature_yes)) {
+                answers = listOfNotNull(
+                    if (isFootway) {
+                        AnswerItem(stringResource(Res.string.quest_is_sidepath_answer_sidewalk)) {
+                            on(Answer(IsSidepathAnswer.IsSidewalk))
+                        }
+                    } else {
+                        null
+                    },
+                    AnswerItem(stringResource(Res.string.quest_is_sidepath_answer_parallel_path)) {
                         step = IsSidepathFormStep.ChooseRoad
                     },
                     AnswerItem(stringResource(Res.string.quest_generic_hasFeature_no)) {
@@ -61,16 +69,7 @@ fun AddIsSidepathForm(
                     },
                 ),
                 otherAnswers = {
-                    listOfNotNull(
-                        if (element.tags["highway"] == "footway") {
-                            AnswerItem(
-                                stringResource(Res.string.quest_is_sidepath_answer_is_sidewalk)
-                            ) {
-                                on(Answer(IsSidepathAnswer.IsSidewalk))
-                            }
-                        } else {
-                            null
-                        },
+                    listOf(
                         AnswerItem(
                             stringResource(Res.string.quest_is_sidepath_answer_is_crossing)
                         ) {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/IsSidepathAnswer.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/IsSidepathAnswer.kt
@@ -1,0 +1,9 @@
+package de.westnordost.streetcomplete.quests.is_sidepath
+
+sealed interface IsSidepathAnswer {
+    /** Sidepath of a road. [ofName] is the selected road's `name=*` when available. */
+    data class Yes(val ofName: String?) : IsSidepathAnswer
+    data object No : IsSidepathAnswer
+    data object IsSidewalk : IsSidepathAnswer
+    data object IsCrossing : IsSidepathAnswer
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/SidepathGeometry.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/SidepathGeometry.kt
@@ -1,0 +1,146 @@
+package de.westnordost.streetcomplete.quests.is_sidepath
+
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.osm.ALL_ROADS
+import de.westnordost.streetcomplete.osm.PEDESTRIAN_ONLY_ROADS
+import de.westnordost.streetcomplete.util.ktx.asSequenceOfPairs
+import de.westnordost.streetcomplete.util.math.distanceToArc
+import de.westnordost.streetcomplete.util.math.enlargedBy
+import de.westnordost.streetcomplete.util.math.initialBearingTo
+import de.westnordost.streetcomplete.util.math.intersect
+import de.westnordost.streetcomplete.util.math.normalizeDegrees
+import kotlin.math.abs
+import kotlin.math.min
+import kotlinx.serialization.Serializable
+
+/** Motor-traffic roads considered for sidepath geometry / candidate list. */
+val SIDEPATH_ROADS: Set<String> = ALL_ROADS - PEDESTRIAN_ONLY_ROADS - setOf("service", "track")
+
+const val MAX_SIDEPATH_DISTANCE_METERS = 20.0
+const val MAX_SIDEPATH_ALIGNMENT_DEGREES = 30.0
+
+/** Extra padding for map-data queries so long roads with sparse nodes are still returned (#3797). */
+const val SIDEPATH_MAP_DATA_QUERY_PADDING_METERS = 100.0
+
+@Serializable
+data class CandidateRoad(
+    val element: Element,
+    val geometry: ElementGeometry,
+    val distance: Double,
+    val alignmentDiff: Double,
+) {
+    val name: String? get() = element.tags["name"]
+    val ref: String? get() = element.tags["ref"]
+    val highway: String? get() = element.tags["highway"]
+}
+
+/** Absolute bearing difference folded so opposite OSM way directions count as parallel. */
+fun alignmentDiffDegrees(bearingA: Double, bearingB: Double): Double {
+    val bearingDiff = abs(normalizeDegrees(bearingA - bearingB, -180.0))
+    return if (bearingDiff > 90.0) 180.0 - bearingDiff else bearingDiff
+}
+
+fun ElementGeometry.asOpenPolylineOrNull(): List<LatLon>? =
+    (this as? ElementPolylinesGeometry)?.polylines?.singleOrNull()?.takeIf { it.size >= 2 }
+
+/**
+ * Returns eligible nearby roads sorted by distance, then alignment, then element id.
+ * Does not deduplicate same-name ways (keeps highlighting unambiguous).
+ */
+fun findCandidateRoads(
+    pathGeometry: ElementGeometry,
+    mapData: MapDataWithGeometry,
+    maxDistance: Double = MAX_SIDEPATH_DISTANCE_METERS,
+    maxAlignment: Double = MAX_SIDEPATH_ALIGNMENT_DEGREES,
+): List<CandidateRoad> {
+    val pathPolyline = pathGeometry.asOpenPolylineOrNull() ?: return emptyList()
+    val pathBounds = pathGeometry.bounds.enlargedBy(maxDistance)
+
+    return mapData.ways.mapNotNull { road ->
+        val highway = road.tags["highway"] ?: return@mapNotNull null
+        if (highway !in SIDEPATH_ROADS) return@mapNotNull null
+        val roadGeometry = mapData.getWayGeometry(road.id) ?: return@mapNotNull null
+        val roadPolyline = roadGeometry.asOpenPolylineOrNull() ?: return@mapNotNull null
+        if (!pathBounds.intersect(roadGeometry.bounds)) return@mapNotNull null
+
+        val match = bestNearAndAlignedPair(pathPolyline, roadPolyline, maxDistance, maxAlignment)
+            ?: return@mapNotNull null
+        CandidateRoad(
+            element = road,
+            geometry = roadGeometry,
+            distance = match.first,
+            alignmentDiff = match.second,
+        )
+    }.sortedWith(
+        compareBy<CandidateRoad> { it.distance }
+            .thenBy { it.alignmentDiff }
+            .thenBy { it.element.id }
+    )
+}
+
+fun hasNearbyAlignedRoad(
+    pathGeometry: ElementGeometry,
+    mapData: MapDataWithGeometry,
+    maxDistance: Double = MAX_SIDEPATH_DISTANCE_METERS,
+    maxAlignment: Double = MAX_SIDEPATH_ALIGNMENT_DEGREES,
+): Boolean {
+    val pathPolyline = pathGeometry.asOpenPolylineOrNull() ?: return false
+    val pathBounds = pathGeometry.bounds.enlargedBy(maxDistance)
+
+    for (road in mapData.ways) {
+        val highway = road.tags["highway"] ?: continue
+        if (highway !in SIDEPATH_ROADS) continue
+        val roadGeometry = mapData.getWayGeometry(road.id) ?: continue
+        val roadPolyline = roadGeometry.asOpenPolylineOrNull() ?: continue
+        if (!pathBounds.intersect(roadGeometry.bounds)) continue
+        if (bestNearAndAlignedPair(pathPolyline, roadPolyline, maxDistance, maxAlignment) != null) {
+            return true
+        }
+    }
+    return false
+}
+
+/** Best matching segment pair as (distance, alignmentDiff), or null if none within thresholds. */
+internal fun bestNearAndAlignedPair(
+    path: List<LatLon>,
+    road: List<LatLon>,
+    maxDistance: Double,
+    maxAlignment: Double,
+): Pair<Double, Double>? {
+    var bestDistance = Double.POSITIVE_INFINITY
+    var bestAlignment = Double.POSITIVE_INFINITY
+
+    for ((p0, p1) in path.asSequenceOfPairs()) {
+        val pathBearing = p0.initialBearingTo(p1)
+        for ((r0, r1) in road.asSequenceOfPairs()) {
+            val distance = segmentCentrelineDistance(p0, p1, r0, r1)
+            if (distance > maxDistance) continue
+            val alignment = alignmentDiffDegrees(pathBearing, r0.initialBearingTo(r1))
+            if (alignment > maxAlignment) continue
+            if (
+                distance < bestDistance ||
+                (distance == bestDistance && alignment < bestAlignment)
+            ) {
+                bestDistance = distance
+                bestAlignment = alignment
+            }
+        }
+    }
+
+    return if (bestDistance.isFinite()) bestDistance to bestAlignment else null
+}
+
+/** Bidirectional vertex-to-arc distance between two segments. */
+internal fun segmentCentrelineDistance(
+    a0: LatLon,
+    a1: LatLon,
+    b0: LatLon,
+    b1: LatLon,
+): Double = min(
+    min(a0.distanceToArc(b0, b1), a1.distanceToArc(b0, b1)),
+    min(b0.distanceToArc(a0, a1), b1.distanceToArc(a0, a1)),
+)

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/AddIsSidepathTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/AddIsSidepathTest.kt
@@ -1,0 +1,330 @@
+package de.westnordost.streetcomplete.quests.is_sidepath
+
+import de.westnordost.streetcomplete.Prefs
+import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapEntryAdd
+import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
+import de.westnordost.streetcomplete.quests.answerApplied
+import de.westnordost.streetcomplete.quests.answerAppliedTo
+import de.westnordost.streetcomplete.testutils.createMapData
+import de.westnordost.streetcomplete.testutils.mockPrefs
+import de.westnordost.streetcomplete.testutils.mockPrefs3
+import de.westnordost.streetcomplete.testutils.p
+import de.westnordost.streetcomplete.testutils.way
+import de.westnordost.streetcomplete.util.math.translate
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AddIsSidepathTest {
+    private lateinit var questType: AddIsSidepath
+
+    @BeforeTest
+    fun setUp() {
+        Prefs.sharedPreferences = mockPrefs()
+        Prefs.preferences = mockPrefs3()
+        questType = AddIsSidepath()
+    }
+
+    // region tagging
+
+    @Test fun `apply no answer`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("is_sidepath", "no")),
+            questType.answerApplied(IsSidepathAnswer.No)
+        )
+    }
+
+    @Test fun `apply yes with road name`() {
+        assertEquals(
+            setOf(
+                StringMapEntryAdd("is_sidepath", "yes"),
+                StringMapEntryAdd("is_sidepath:of:name", "Hauptstraße"),
+            ),
+            questType.answerApplied(IsSidepathAnswer.Yes(ofName = "Hauptstraße"))
+        )
+    }
+
+    @Test fun `apply yes without road name`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("is_sidepath", "yes")),
+            questType.answerApplied(IsSidepathAnswer.Yes(ofName = null))
+        )
+    }
+
+    @Test fun `apply yes with empty road name writes only is_sidepath`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("is_sidepath", "yes")),
+            questType.answerApplied(IsSidepathAnswer.Yes(ofName = ""))
+        )
+    }
+
+    @Test fun `apply yes never writes is_sidepath of or of ref`() {
+        val changes = questType.answerApplied(IsSidepathAnswer.Yes(ofName = "Hauptstraße"))
+        assertTrue(changes.none { it.key == "is_sidepath:of" })
+        assertTrue(changes.none { it.key == "is_sidepath:of:ref" })
+    }
+
+    @Test fun `apply sidewalk answer`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("footway", "sidewalk")),
+            questType.answerAppliedTo(
+                IsSidepathAnswer.IsSidewalk,
+                mapOf("highway" to "footway")
+            )
+        )
+    }
+
+    @Test fun `apply crossing answer for footway`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("footway", "crossing")),
+            questType.answerAppliedTo(
+                IsSidepathAnswer.IsCrossing,
+                mapOf("highway" to "footway")
+            )
+        )
+    }
+
+    @Test fun `apply crossing answer for cycleway`() {
+        assertEquals(
+            setOf(StringMapEntryAdd("cycleway", "crossing")),
+            questType.answerAppliedTo(
+                IsSidepathAnswer.IsCrossing,
+                mapOf("highway" to "cycleway")
+            )
+        )
+    }
+
+    // endregion
+
+    // region isApplicableTo
+
+    @Test fun `isApplicableTo is true for matching path regardless of nearby roads`() {
+        val path = way(tags = mapOf("highway" to "footway"))
+        assertTrue(questType.isApplicableTo(path))
+    }
+
+    @Test fun `isApplicableTo is false for non-matching element`() {
+        val road = way(tags = mapOf("highway" to "residential"))
+        assertFalse(questType.isApplicableTo(road))
+    }
+
+    @Test fun `isApplicableTo is false for already tagged sidepath`() {
+        val path = way(tags = mapOf("highway" to "footway", "is_sidepath" to "yes"))
+        assertFalse(questType.isApplicableTo(path))
+    }
+
+    // endregion
+
+    // region geometry gating
+
+    @Test fun `applicable to parallel footway 5m from residential`() {
+        assertEquals(1, applicableCount(pathAndRoad(pathOffsetMeters = 5.0, roadHighway = "residential")))
+    }
+
+    @Test fun `applicable to parallel cycleway about 13m from secondary`() {
+        assertEquals(
+            1,
+            applicableCount(
+                pathAndRoad(
+                    pathOffsetMeters = 13.0,
+                    pathTags = mapOf("highway" to "cycleway"),
+                    roadHighway = "secondary",
+                )
+            )
+        )
+    }
+
+    @Test fun `applicable to parallel path about 19m away`() {
+        assertEquals(
+            1,
+            applicableCount(
+                pathAndRoad(
+                    pathOffsetMeters = 19.0,
+                    pathTags = mapOf("highway" to "path", "foot" to "yes"),
+                )
+            )
+        )
+    }
+
+    @Test fun `not applicable when path is more than 20m away`() {
+        assertEquals(0, applicableCount(pathAndRoad(pathOffsetMeters = 21.0)))
+    }
+
+    @Test fun `not applicable to isolated path`() {
+        val p1 = p(0.0, 0.0)
+        val p2 = p1.translate(50.0, 45.0)
+        val path = way(1, listOf(1, 2), mapOf("highway" to "footway"))
+        val mapData = createMapData(mapOf(
+            path to ElementPolylinesGeometry(listOf(listOf(p1, p2)), p1)
+        ))
+        assertEquals(0, questType.getApplicableElements(mapData).toList().size)
+    }
+
+    @Test fun `not applicable when only nearby service road`() {
+        assertEquals(0, applicableCount(pathAndRoad(pathOffsetMeters = 5.0, roadHighway = "service")))
+    }
+
+    @Test fun `not applicable when only nearby track`() {
+        assertEquals(0, applicableCount(pathAndRoad(pathOffsetMeters = 5.0, roadHighway = "track")))
+    }
+
+    @Test fun `not applicable when only nearby pedestrian road`() {
+        assertEquals(0, applicableCount(pathAndRoad(pathOffsetMeters = 5.0, roadHighway = "pedestrian")))
+    }
+
+    @Test fun `not applicable to perpendicular crossing`() {
+        val roadStart = p(0.0, 0.0)
+        val roadEnd = roadStart.translate(50.0, 0.0)
+        // Path crosses roughly perpendicular near the middle
+        val pathStart = roadStart.translate(25.0, 0.0).translate(10.0, 90.0)
+        val pathEnd = roadStart.translate(25.0, 0.0).translate(10.0, 270.0)
+
+        val road = way(1, listOf(1, 2), mapOf("highway" to "residential"))
+        val path = way(2, listOf(3, 4), mapOf("highway" to "footway"))
+        val mapData = createMapData(mapOf(
+            road to ElementPolylinesGeometry(listOf(listOf(roadStart, roadEnd)), roadStart),
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+        ))
+        assertEquals(0, questType.getApplicableElements(mapData).toList().size)
+    }
+
+    @Test fun `applicable when road is tagged in opposite way direction`() {
+        val roadStart = p(0.0, 0.0)
+        val roadEnd = roadStart.translate(50.0, 45.0)
+        val pathStart = roadStart.translate(5.0, 135.0)
+        val pathEnd = pathStart.translate(50.0, 45.0)
+
+        val road = way(1, listOf(1, 2), mapOf("highway" to "residential"))
+        val path = way(2, listOf(3, 4), mapOf("highway" to "footway"))
+        // Road geometry reversed relative to path direction
+        val mapData = createMapData(mapOf(
+            road to ElementPolylinesGeometry(listOf(listOf(roadEnd, roadStart)), roadEnd),
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+        ))
+        assertEquals(1, questType.getApplicableElements(mapData).toList().size)
+    }
+
+    @Test fun `applicable to short legitimate parallel sidepath`() {
+        val roadStart = p(0.0, 0.0)
+        val roadEnd = roadStart.translate(12.0, 45.0)
+        val pathStart = roadStart.translate(5.0, 135.0)
+        val pathEnd = pathStart.translate(12.0, 45.0)
+
+        val road = way(1, listOf(1, 2), mapOf("highway" to "residential"))
+        val path = way(2, listOf(3, 4), mapOf("highway" to "footway"))
+        val mapData = createMapData(mapOf(
+            road to ElementPolylinesGeometry(listOf(listOf(roadStart, roadEnd)), roadStart),
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+        ))
+        assertEquals(1, questType.getApplicableElements(mapData).toList().size)
+    }
+
+    @Test fun `applicable to curved road and curved sidepath`() {
+        val r0 = p(0.0, 0.0)
+        val r1 = r0.translate(30.0, 45.0)
+        val r2 = r1.translate(30.0, 60.0)
+        val p0 = r0.translate(5.0, 135.0)
+        val p1 = r1.translate(5.0, 150.0)
+        val p2 = r2.translate(5.0, 150.0)
+
+        val road = way(1, listOf(1, 2, 3), mapOf("highway" to "residential"))
+        val path = way(2, listOf(4, 5, 6), mapOf("highway" to "footway"))
+        val mapData = createMapData(mapOf(
+            road to ElementPolylinesGeometry(listOf(listOf(r0, r1, r2)), r1),
+            path to ElementPolylinesGeometry(listOf(listOf(p0, p1, p2)), p1),
+        ))
+        assertEquals(1, questType.getApplicableElements(mapData).toList().size)
+    }
+
+    @Test fun `applicable with dual carriageway nearby`() {
+        val roadStart = p(0.0, 0.0)
+        val roadEnd = roadStart.translate(50.0, 45.0)
+        val road2Start = roadStart.translate(8.0, 135.0)
+        val road2End = road2Start.translate(50.0, 45.0)
+        val pathStart = roadStart.translate(4.0, 135.0)
+        val pathEnd = pathStart.translate(50.0, 45.0)
+
+        val road1 = way(1, listOf(1, 2), mapOf("highway" to "primary", "name" to "Hauptstraße", "oneway" to "yes"))
+        val road2 = way(2, listOf(3, 4), mapOf("highway" to "primary", "name" to "Hauptstraße", "oneway" to "yes"))
+        val path = way(3, listOf(5, 6), mapOf("highway" to "footway"))
+        val mapData = createMapData(mapOf(
+            road1 to ElementPolylinesGeometry(listOf(listOf(roadStart, roadEnd)), roadStart),
+            road2 to ElementPolylinesGeometry(listOf(listOf(road2Start, road2End)), road2Start),
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+        ))
+        assertEquals(1, questType.getApplicableElements(mapData).toList().size)
+    }
+
+    @Test fun `tag exclusions win despite nearby parallel road`() {
+        assertEquals(
+            0,
+            applicableCount(
+                pathAndRoad(
+                    pathOffsetMeters = 5.0,
+                    pathTags = mapOf("highway" to "footway", "footway" to "sidewalk"),
+                )
+            )
+        )
+        assertEquals(
+            0,
+            applicableCount(
+                pathAndRoad(
+                    pathOffsetMeters = 5.0,
+                    pathTags = mapOf("highway" to "footway", "footway" to "crossing"),
+                )
+            )
+        )
+        assertEquals(
+            0,
+            applicableCount(
+                pathAndRoad(
+                    pathOffsetMeters = 5.0,
+                    pathTags = mapOf("highway" to "cycleway", "cycleway" to "link"),
+                )
+            )
+        )
+    }
+
+    @Test fun `missing path geometry is not applicable and does not crash`() {
+        val roadStart = p(0.0, 0.0)
+        val roadEnd = roadStart.translate(50.0, 45.0)
+        val road = way(1, listOf(1, 2), mapOf("highway" to "residential"))
+        val path = way(2, listOf(3, 4), mapOf("highway" to "footway"))
+        val mapData = createMapData(mapOf(
+            road to ElementPolylinesGeometry(listOf(listOf(roadStart, roadEnd)), roadStart),
+            path to null,
+        ))
+        assertEquals(0, questType.getApplicableElements(mapData).toList().size)
+    }
+
+    @Test fun `boundary distance 20m is applicable`() {
+        assertEquals(1, applicableCount(pathAndRoad(pathOffsetMeters = 20.0)))
+    }
+
+    // endregion
+
+    private fun applicableCount(mapData: Map<de.westnordost.streetcomplete.data.osm.mapdata.Element, de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry?>): Int =
+        questType.getApplicableElements(createMapData(mapData)).toList().size
+
+    private fun pathAndRoad(
+        pathOffsetMeters: Double,
+        pathTags: Map<String, String> = mapOf("highway" to "footway"),
+        roadHighway: String = "residential",
+        roadLengthMeters: Double = 50.0,
+        bearing: Double = 45.0,
+    ): Map<de.westnordost.streetcomplete.data.osm.mapdata.Element, de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry?> {
+        val roadStart = p(0.0, 0.0)
+        val roadEnd = roadStart.translate(roadLengthMeters, bearing)
+        val pathStart = roadStart.translate(pathOffsetMeters, bearing + 90.0)
+        val pathEnd = pathStart.translate(roadLengthMeters, bearing)
+
+        val road = way(1, listOf(1, 2), mapOf("highway" to roadHighway))
+        val path = way(2, listOf(3, 4), pathTags)
+        return mapOf(
+            road to ElementPolylinesGeometry(listOf(listOf(roadStart, roadEnd)), roadStart),
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+        )
+    }
+}

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/SidepathGeometryTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/quests/is_sidepath/SidepathGeometryTest.kt
@@ -1,0 +1,174 @@
+package de.westnordost.streetcomplete.quests.is_sidepath
+
+import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
+import de.westnordost.streetcomplete.testutils.createMapData
+import de.westnordost.streetcomplete.testutils.p
+import de.westnordost.streetcomplete.testutils.way
+import de.westnordost.streetcomplete.util.math.translate
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SidepathGeometryTest {
+
+    @Test fun `alignment diff treats opposite bearings as parallel`() {
+        assertEquals(0.0, alignmentDiffDegrees(10.0, 190.0), 1e-9)
+        assertEquals(0.0, alignmentDiffDegrees(0.0, 180.0), 1e-9)
+        assertEquals(30.0, alignmentDiffDegrees(0.0, 30.0), 1e-9)
+        assertEquals(30.0, alignmentDiffDegrees(0.0, 150.0), 1e-9)
+    }
+
+    @Test fun `candidates ordered by distance then alignment then id`() {
+        val pathStart = p(0.0, 0.0)
+        val pathEnd = pathStart.translate(50.0, 45.0)
+        val path = way(10, listOf(100, 101), mapOf("highway" to "footway"))
+
+        // farther but better aligned
+        val farStart = pathStart.translate(12.0, 135.0)
+        val farEnd = farStart.translate(50.0, 45.0)
+        val farRoad = way(2, listOf(1, 2), mapOf("highway" to "residential", "name" to "Far"))
+
+        // nearer
+        val nearStart = pathStart.translate(5.0, 135.0)
+        val nearEnd = nearStart.translate(50.0, 45.0)
+        val nearRoad = way(3, listOf(3, 4), mapOf("highway" to "residential", "name" to "Near"))
+
+        // same distance band as near, slightly worse alignment, smaller id than another twin
+        val near2Start = pathStart.translate(5.2, 135.0)
+        val near2End = near2Start.translate(50.0, 50.0)
+        val near2Road = way(1, listOf(5, 6), mapOf("highway" to "residential", "name" to "Nearish"))
+
+        val mapData = createMapData(mapOf(
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+            farRoad to ElementPolylinesGeometry(listOf(listOf(farStart, farEnd)), farStart),
+            nearRoad to ElementPolylinesGeometry(listOf(listOf(nearStart, nearEnd)), nearStart),
+            near2Road to ElementPolylinesGeometry(listOf(listOf(near2Start, near2End)), near2Start),
+        ))
+
+        val candidates = findCandidateRoads(
+            mapData.getWayGeometry(path.id)!!,
+            mapData,
+        )
+        assertEquals(listOf(3L, 1L, 2L), candidates.map { it.element.id })
+        assertTrue(candidates[0].distance <= candidates[1].distance)
+        assertTrue(candidates[1].distance <= candidates[2].distance)
+    }
+
+    @Test fun `named and unnamed roads are both returned`() {
+        val pathStart = p(0.0, 0.0)
+        val pathEnd = pathStart.translate(40.0, 0.0)
+        val path = way(1, listOf(1, 2), mapOf("highway" to "footway"))
+
+        val namedStart = pathStart.translate(5.0, 90.0)
+        val namedEnd = namedStart.translate(40.0, 0.0)
+        val named = way(2, listOf(3, 4), mapOf("highway" to "residential", "name" to "Bahnhofstraße"))
+
+        val unnamedStart = pathStart.translate(8.0, 270.0)
+        val unnamedEnd = unnamedStart.translate(40.0, 0.0)
+        val unnamed = way(3, listOf(5, 6), mapOf("highway" to "residential"))
+
+        val mapData = createMapData(mapOf(
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+            named to ElementPolylinesGeometry(listOf(listOf(namedStart, namedEnd)), namedStart),
+            unnamed to ElementPolylinesGeometry(listOf(listOf(unnamedStart, unnamedEnd)), unnamedStart),
+        ))
+
+        val candidates = findCandidateRoads(mapData.getWayGeometry(path.id)!!, mapData)
+        assertEquals(2, candidates.size)
+        assertEquals("Bahnhofstraße", candidates.first { it.element.id == 2L }.name)
+        assertNull(candidates.first { it.element.id == 3L }.name)
+    }
+
+    @Test fun `multiple differently named roads all remain candidates`() {
+        val pathStart = p(0.0, 0.0)
+        val pathEnd = pathStart.translate(40.0, 0.0)
+        val path = way(1, listOf(1, 2), mapOf("highway" to "footway"))
+
+        val aStart = pathStart.translate(5.0, 90.0)
+        val aEnd = aStart.translate(40.0, 0.0)
+        val a = way(2, listOf(3, 4), mapOf("highway" to "residential", "name" to "Hauptstraße"))
+
+        val bStart = pathStart.translate(6.0, 270.0)
+        val bEnd = bStart.translate(40.0, 0.0)
+        val b = way(3, listOf(5, 6), mapOf("highway" to "secondary", "name" to "Bahnhofstraße"))
+
+        val mapData = createMapData(mapOf(
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+            a to ElementPolylinesGeometry(listOf(listOf(aStart, aEnd)), aStart),
+            b to ElementPolylinesGeometry(listOf(listOf(bStart, bEnd)), bStart),
+        ))
+
+        val candidates = findCandidateRoads(mapData.getWayGeometry(path.id)!!, mapData)
+        assertEquals(setOf("Hauptstraße", "Bahnhofstraße"), candidates.mapNotNull { it.name }.toSet())
+    }
+
+    @Test fun `dual carriageway same name keeps both ways as candidates`() {
+        val pathStart = p(0.0, 0.0)
+        val pathEnd = pathStart.translate(50.0, 45.0)
+        val path = way(1, listOf(1, 2), mapOf("highway" to "footway"))
+
+        val r1Start = pathStart.translate(4.0, 135.0)
+        val r1End = r1Start.translate(50.0, 45.0)
+        val r1 = way(2, listOf(3, 4), mapOf("highway" to "primary", "name" to "Hauptstraße"))
+
+        val r2Start = pathStart.translate(10.0, 135.0)
+        val r2End = r2Start.translate(50.0, 45.0)
+        val r2 = way(3, listOf(5, 6), mapOf("highway" to "primary", "name" to "Hauptstraße"))
+
+        val mapData = createMapData(mapOf(
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+            r1 to ElementPolylinesGeometry(listOf(listOf(r1Start, r1End)), r1Start),
+            r2 to ElementPolylinesGeometry(listOf(listOf(r2Start, r2End)), r2Start),
+        ))
+
+        val candidates = findCandidateRoads(mapData.getWayGeometry(path.id)!!, mapData)
+        assertEquals(2, candidates.size)
+        assertTrue(candidates.all { it.name == "Hauptstraße" })
+    }
+
+    @Test fun `no candidates when nothing nearby`() {
+        val pathStart = p(0.0, 0.0)
+        val pathEnd = pathStart.translate(40.0, 0.0)
+        val path = way(1, listOf(1, 2), mapOf("highway" to "footway"))
+        val mapData = createMapData(mapOf(
+            path to ElementPolylinesGeometry(listOf(listOf(pathStart, pathEnd)), pathStart),
+        ))
+        assertEquals(emptyList(), findCandidateRoads(mapData.getWayGeometry(path.id)!!, mapData))
+    }
+
+    @Test fun `alignment boundary of 30 degrees is accepted`() {
+        val pathStart = p(0.0, 0.0)
+        val pathEnd = pathStart.translate(40.0, 0.0)
+        val roadStart = pathStart.translate(5.0, 90.0)
+        val roadEnd = roadStart.translate(40.0, 30.0)
+
+        val match = assertNotNull(
+            bestNearAndAlignedPair(
+                listOf(pathStart, pathEnd),
+                listOf(roadStart, roadEnd),
+                MAX_SIDEPATH_DISTANCE_METERS,
+                MAX_SIDEPATH_ALIGNMENT_DEGREES,
+            )
+        )
+        assertTrue(abs(match.second - 30.0) < 1.0)
+    }
+
+    @Test fun `alignment beyond 30 degrees is rejected`() {
+        val pathStart = p(0.0, 0.0)
+        val pathEnd = pathStart.translate(40.0, 0.0)
+        val roadStart = pathStart.translate(5.0, 90.0)
+        val roadEnd = roadStart.translate(40.0, 40.0)
+
+        assertNull(
+            bestNearAndAlignedPair(
+                listOf(pathStart, pathEnd),
+                listOf(roadStart, roadEnd),
+                MAX_SIDEPATH_DISTANCE_METERS,
+                MAX_SIDEPATH_ALIGNMENT_DEGREES,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `is_sidepath` quest from #899 with geometry-based quest gating and optional road association.

## What changed

- only shows the quest for paths with a plausible nearby parallel road
- uses a 20 m / 30° geometry gate
- excludes `service`, `track` and `pedestrian` roads from candidates
- keeps `isApplicableTo` tag-only to avoid unreliable geometry re-evaluation
- adds a second in-form step to select the corresponding road
- highlights the selected road on the map
- writes `is_sidepath=yes/no`
- optionally writes `is_sidepath:of:name`
- keeps the whole answer as one atomic edit
- supports "Can't say" as a safe fallback

No automatic road association or map-click selection is used.

## Testing

- `:app:compileAndroidMain`
- `:app:testAndroidHostTest --tests "de.westnordost.streetcomplete.quests.is_sidepath.*"`
- https://github.com/Helium314/SCEE/issues/899#issuecomment-5608882942

Both pass successfully.

Fixes #899