### PR TITLE
Fix custom overlay content layout

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/custom/CustomOverlay.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/overlays/custom/CustomOverlay.kt
@@ -1,13 +1,19 @@
 package de.westnordost.streetcomplete.overlays.custom
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import androidx.core.graphics.toColorInt
 import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.data.elementfilter.ElementFilterExpression
@@ -35,6 +41,7 @@ import de.westnordost.streetcomplete.screens.main.bottom_sheet.EditTagsForm
 import de.westnordost.streetcomplete.ui.common.overlay.OverlayForm
 import de.westnordost.streetcomplete.ui.common.quest.AnswerItem
 import de.westnordost.streetcomplete.ui.common.quest.ConfirmDeleteDialog
+import de.westnordost.streetcomplete.ui.theme.titleLarge
 import de.westnordost.streetcomplete.util.getCurrentCustomOverlayPref
 import de.westnordost.streetcomplete.util.getNameLabel
 import de.westnordost.streetcomplete.util.ktx.isArea
@@ -99,6 +106,7 @@ class CustomOverlay(val prefs: Preferences) : Overlay {
                     } else null
                 ) },
             ) {
+                // Single Column: OverlayContent uses a centered Box; siblings would overlap.
                 val colorKeyPref = prefs.getString(getCurrentCustomOverlayPref(Prefs.CUSTOM_OVERLAY_IDX_COLOR_KEY, prefs), "")
                 val colorKeySelector = try {
                     val actualColorKeyPref = if (colorKeyPref.startsWith("!"))
@@ -109,14 +117,27 @@ class CustomOverlay(val prefs: Preferences) : Overlay {
                 val colorTags = if (colorKeySelector != null)
                     element.tags.filter { it.key.matches(colorKeySelector) }
                 else null
-                if (colorTags != null)
-                Text(colorTags.entries.sortedBy { it.key }.joinToString("\n") { "${it.key} = ${it.value}" })
-                TextButton({
-                    if (colorKeyPref.startsWith("!") && !colorKeyPref.contains(' '))
-                        focusKey = colorKeyPref
-                    on(Action.EditTags)
-                }) {
-                    Text(stringResource(Res.string.quest_generic_answer_show_edit_tags))
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    if (colorTags != null) {
+                        Text(
+                            text = formatCustomOverlayColorTags(colorTags),
+                            modifier = Modifier.fillMaxWidth(),
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                    }
+                    Button(
+                        onClick = {
+                            if (colorKeyPref.startsWith("!") && !colorKeyPref.contains(' '))
+                                focusKey = colorKeyPref
+                            on(Action.EditTags)
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(stringResource(Res.string.quest_generic_answer_show_edit_tags))
+                    }
                 }
             }
         }
@@ -133,6 +154,10 @@ class CustomOverlay(val prefs: Preferences) : Overlay {
         var focusKey: String? = null
     }
 }
+
+/** Display text for matching color-key tags (pre-Compose CustomOverlayForm format). */
+internal fun formatCustomOverlayColorTags(colorTags: Map<String, String>): String =
+    colorTags.entries.sortedBy { it.key }.joinToString("\n") { "${it.key} = ${it.value}" }
 
 private fun getStyle(element: Element, colorKeySelector: Regex?, dashFilter: ElementFilterExpression?, defaultMissingColor: Color): OverlayStyle {
     val color by lazy {

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/custom/CustomOverlayColorTagsTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/overlays/custom/CustomOverlayColorTagsTest.kt
@@ -1,0 +1,32 @@
+package de.westnordost.streetcomplete.overlays.custom
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CustomOverlayColorTagsTest {
+
+    @Test fun `formats a single color tag`() {
+        assertEquals(
+            "surface = asphalt",
+            formatCustomOverlayColorTags(mapOf("surface" to "asphalt"))
+        )
+    }
+
+    @Test fun `formats multiple color tags sorted by key on separate lines`() {
+        assertEquals(
+            "building:levels = 3\nsurface = grass",
+            formatCustomOverlayColorTags(mapOf(
+                "surface" to "grass",
+                "building:levels" to "3",
+            ))
+        )
+    }
+
+    @Test fun `preserves long values on one line per tag`() {
+        val longValue = "a".repeat(80)
+        assertEquals(
+            "note = $longValue",
+            formatCustomOverlayColorTags(mapOf("note" to longValue))
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a Compose migration regression in the Custom Overlay form.

The color-tag text and the visible "Edit tags" action were rendered as sibling composables inside a centered `Box`, causing them to overlap.

This restores the pre-Compose layout:
- matching color tags are shown vertically above the action
- the "Edit tags" action is shown as a full-width primary button
- existing `focusKey` and edit-tags behavior is preserved
- shared overlay layout is left unchanged

## Testing

- `:app:compileAndroidMain` passes
- `CustomOverlayColorTagsTest`: 3/3 tests pass
- manually verified on Android

Before:
<img width="245" height="76" alt="2026-09-09 23_39_55-StreetComplete – AddPathSurface kt  StreetComplete app commonMain" src="https://github.com/user-attachments/assets/1c6a1f36-089b-425b-b8fa-f460bac98ed5" />

After:
<img width="245" height="122" alt="2026-09-09 23_57_48-StreetComplete – AddPathSurface kt  StreetComplete app commonMain" src="https://github.com/user-attachments/assets/83a34567-7943-41d9-a801-4773085771c0" />
